### PR TITLE
Add customizable background color

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -12,8 +12,47 @@ private enum Theme {
     static let borderHover = Color.primary.opacity(0.15)
     static let muted = Color.primary.opacity(0.04)
     static let mutedHover = Color.primary.opacity(0.08)
-    static let accent = Color(red: 0.56, green: 0.39, blue: 0.98)  // indigo-ish
+    static let accent = Color(red: 0.56, green: 0.39, blue: 0.98)
     static let accentMuted = Color(red: 0.56, green: 0.39, blue: 0.98).opacity(0.1)
+
+    struct ColorPreset {
+        let hex: String
+        let name: String
+    }
+
+
+    static let backgroundPresets: [ColorPreset] = [
+        .init(hex: "FFFFFF", name: "White"),
+        .init(hex: "D6E4FF", name: "Blue"),
+        .init(hex: "D1FAE5", name: "Green"),
+        .init(hex: "FFE4CC", name: "Peach"),
+        .init(hex: "FBCFE8", name: "Pink"),
+        .init(hex: "DDD6FE", name: "Lavender"),
+        .init(hex: "C7F5FE", name: "Cyan"),
+        .init(hex: "FEF3C7", name: "Cream"),
+    ]
+}
+
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        let scanner = Scanner(string: hex)
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >> 8) & 0xFF) / 255.0
+        let b = Double(rgb & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+
+    var hexString: String {
+        guard let components = NSColor(self).usingColorSpace(.sRGB) else { return "8F63FB" }
+        let r = Int(components.redComponent * 255)
+        let g = Int(components.greenComponent * 255)
+        let b = Int(components.blueComponent * 255)
+        return String(format: "%02X%02X%02X", r, g, b)
+    }
 }
 
 // MARK: - Main view
@@ -91,6 +130,9 @@ struct MenuBarView: View {
                 .padding(.vertical, 8)
         }
         .frame(width: manager.compactMode && !manager.showSettings && manager.selectedTab == .usage ? 300 : 400)
+        .background(manager.backgroundColorHex.map { hex in
+            manager.opaqueBackground ? Color(hex: hex) : Color(hex: hex).opacity(0.25)
+        })
         .animation(.easeOut(duration: 0.15), value: manager.selectedTab)
         .animation(.easeOut(duration: 0.15), value: manager.showSettings)
         .onAppear {
@@ -486,6 +528,43 @@ struct MenuBarView: View {
                         .font(.system(size: 12))
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                    SHDivider()
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Background")
+                            .font(.system(size: 12))
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(Color.clear)
+                                .frame(width: 22, height: 22)
+                                .overlay(Circle().stroke(Color.primary.opacity(0.2), lineWidth: 1))
+                                .overlay(
+                                    Image(systemName: "sparkle")
+                                        .font(.system(size: 9))
+                                        .foregroundColor(.secondary)
+                                )
+                                .overlay(
+                                    Circle().stroke(Color.primary.opacity(manager.backgroundColorHex == nil ? 0.6 : 0), lineWidth: 2)
+                                )
+                                .onTapGesture { manager.backgroundColorHex = nil }
+
+                            ForEach(Theme.backgroundPresets, id: \.hex) { preset in
+                                Circle()
+                                    .fill(Color(hex: preset.hex))
+                                    .frame(width: 22, height: 22)
+                                    .overlay(Circle().stroke(Color.primary.opacity(0.1), lineWidth: 1))
+                                    .overlay(
+                                        Circle().stroke(Color.primary.opacity(manager.backgroundColorHex == preset.hex ? 0.6 : 0), lineWidth: 2)
+                                    )
+                                    .onTapGesture { manager.backgroundColorHex = preset.hex }
+                            }
+                        }
+                        if manager.backgroundColorHex != nil {
+                            Toggle("Opaque", isOn: $manager.opaqueBackground)
+                                .font(.system(size: 12))
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                        }
+                    }
                 }
             }
 
@@ -3721,7 +3800,7 @@ struct HeatmapGrid: View {
 
     private func color(for day: HeatmapDay) -> Color {
         let level = day.intensity(maxCost: maxCost)
-        let base = Color(red: 0.56, green: 0.39, blue: 0.98)
+        let base = Theme.accent
         switch level {
         case 0: return colorScheme == .dark ? Color.primary.opacity(0.06) : Color.primary.opacity(0.04)
         case 1: return base.opacity(0.25)
@@ -3761,7 +3840,7 @@ struct HeatmapGrid: View {
                     RoundedRectangle(cornerRadius: 1.5, style: .continuous)
                         .fill(level == 0
                             ? (colorScheme == .dark ? Color.primary.opacity(0.06) : Color.primary.opacity(0.04))
-                            : Color(red: 0.56, green: 0.39, blue: 0.98).opacity(Double(level) * 0.25))
+                            : Theme.accent.opacity(Double(level) * 0.25))
                         .frame(width: 7, height: 7)
                 }
                 Text("More")

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -36,7 +36,8 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     case iconOnly = 0
     case percentage = 1
     case percentageAndTimer = 2
-    case allQuotas = 3
+    case fullDashboard = 3
+    case allQuotas = 4
 
     var id: Int { rawValue }
 
@@ -45,6 +46,7 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
         case .iconOnly: return "Icon"
         case .percentage: return "Session"
         case .percentageAndTimer: return "Timer"
+        case .fullDashboard: return "Dashboard"
         case .allQuotas: return "All"
         }
     }
@@ -54,6 +56,7 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
         case .iconOnly: return "C"
         case .percentage: return "C 15%"
         case .percentageAndTimer: return "C 15% · 2h31m"
+        case .fullDashboard: return "C 15% · 2h31m | 9% · 5j"
         case .allQuotas: return "C 15% | 31% | 22%"
         }
     }
@@ -206,6 +209,8 @@ class UsageManager: ObservableObject {
     @Published var errorMessage: String?
     @Published var lastRefresh: Date?
     @Published var timeUntilReset: String = "—"
+    @Published var timeUntilSessionReset: String = "—"
+    @Published var timeUntilWeeklyReset: String = "—"
 
     // MARK: - Live session cost
 
@@ -347,6 +352,14 @@ class UsageManager: ObservableObject {
         quotas.first(where: { $0.label.contains("Session") }) ?? quotas.first
     }
 
+    var sessionQuota: UsageQuota? {
+        quotas.first(where: { $0.label.contains("Session") })
+    }
+
+    var weeklyQuota: UsageQuota? {
+        quotas.first(where: { $0.label.contains("Weekly") })
+    }
+
     /// The quota with the highest utilization (worst state)
     private var worstQuota: UsageQuota? {
         quotas.max(by: { $0.utilization < $1.utilization })
@@ -366,6 +379,18 @@ class UsageManager: ObservableObject {
         case .allQuotas:
             if quotas.isEmpty { return "—" }
             return quotas.map { "\(Int($0.utilization))%" }.joined(separator: " | ")
+        case .fullDashboard:
+            let sessionPart: String = {
+                guard let s = sessionQuota else { return "—" }
+                let timer = timeUntilSessionReset == "—" ? "" : " · \(timeUntilSessionReset)"
+                return "\(Int(s.utilization))%\(timer)"
+            }()
+            let weeklyPart: String = {
+                guard let w = weeklyQuota else { return "—" }
+                let timer = timeUntilWeeklyReset == "—" ? "" : " · \(timeUntilWeeklyReset)"
+                return "\(Int(w.utilization))%\(timer)"
+            }()
+            return "\(sessionPart) | \(weeklyPart)"
         }
     }
 
@@ -1160,12 +1185,27 @@ class UsageManager: ObservableObject {
 
     private func setupCountdownTimer() {
         countdownTimer?.cancel()
-        let interval: TimeInterval = menuBarDisplayMode == .percentageAndTimer ? 1 : 30
+        let needsFastTimer = menuBarDisplayMode == .percentageAndTimer || menuBarDisplayMode == .fullDashboard
+        let interval: TimeInterval = needsFastTimer ? 1 : 30
         countdownTimer = Timer.publish(every: interval, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 self?.updateCountdown()
             }
+    }
+
+    /// Format a time interval as the largest meaningful unit only
+    private static func compactTimeString(_ remaining: TimeInterval) -> String {
+        let totalSeconds = Int(remaining)
+        let days = totalSeconds / 86400
+        let hours = (totalSeconds % 86400) / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if days > 0 { return "\(days)j" }
+        if hours > 0 { return "\(hours)h\(String(format: "%02d", minutes))m" }
+        if minutes > 0 { return "\(minutes)m\(String(format: "%02d", seconds))s" }
+        return "\(seconds)s"
     }
 
     private func updateCountdown() {
@@ -1208,6 +1248,19 @@ class UsageManager: ObservableObject {
             }
         }
         if timeUntilReset != newValue { timeUntilReset = newValue }
+
+        // Update per-quota timers for fullDashboard mode
+        if menuBarDisplayMode == .fullDashboard {
+            let sessionValue = sessionQuota?.resetsAt
+                .map { max(0, $0.timeIntervalSinceNow) }
+                .map(Self.compactTimeString) ?? "—"
+            if timeUntilSessionReset != sessionValue { timeUntilSessionReset = sessionValue }
+
+            let weeklyValue = weeklyQuota?.resetsAt
+                .map { max(0, $0.timeIntervalSinceNow) }
+                .map(Self.compactTimeString) ?? "—"
+            if timeUntilWeeklyReset != weeklyValue { timeUntilWeeklyReset = weeklyValue }
+        }
     }
 
     // MARK: - Auto-refresh

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -346,6 +346,22 @@ class UsageManager: ObservableObject {
         }
     }
 
+    @Published var opaqueBackground: Bool {
+        didSet {
+            UserDefaults.standard.set(opaqueBackground, forKey: "opaqueBackground")
+        }
+    }
+
+    @Published var backgroundColorHex: String? {
+        didSet {
+            if let hex = backgroundColorHex {
+                UserDefaults.standard.set(hex, forKey: "backgroundColorHex")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "backgroundColorHex")
+            }
+        }
+    }
+
     // MARK: - Propriétés calculées
 
     var primaryQuota: UsageQuota? {
@@ -563,6 +579,8 @@ class UsageManager: ObservableObject {
         let savedDisplayMode = ud.integer(forKey: UDKey.menuBarDisplayMode)
         self.menuBarDisplayMode = MenuBarDisplayMode(rawValue: savedDisplayMode) ?? .percentageAndTimer
         self.dailyBudget = ud.double(forKey: UDKey.dailyBudget)
+        self.opaqueBackground = ud.bool(forKey: "opaqueBackground")
+        self.backgroundColorHex = ud.string(forKey: "backgroundColorHex")
 
         // Load per-project budgets
         if let data = ud.data(forKey: UDKey.projectBudgets),


### PR DESCRIPTION
## Summary
- Adds a **Background** color picker in the Preferences section (alongside Compact mode and Launch at login)
- 8 pastel presets (white, blue, green, peach, pink, lavender, cyan, cream) + system translucent default
- Colors apply at 25% opacity to blend with the macOS translucent material
- **Opaque** toggle appears when a color is selected for a solid fill
- Persisted in UserDefaults

## Changes
- `MenuBarView.swift`: Background color picker UI with preset circles, `Color(hex:)` / `hexString` extensions, `Theme.backgroundPresets`
- `UsageManager.swift`: `backgroundColorHex` (optional String) and `opaqueBackground` (Bool) published properties with UserDefaults persistence