### PR TITLE
fix: respect Retry-After header on 429 instead of capping to 60s

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -97,12 +97,19 @@ class AuthManager: ObservableObject {
         return Date().addingTimeInterval(5 * 60) >= expiresDate
     }
 
-    /// Reload credentials from disk only (not keychain) to avoid interfering with Claude Code.
-    /// Claude Code manages the OAuth refresh cycle — we should not compete for keychain access.
+    var tokenExpired: Bool {
+        guard let expiresAt = tokenExpiresAt else { return false }
+        let expiresDate = Date(timeIntervalSince1970: expiresAt / 1000)
+        return Date() >= expiresDate
+    }
+
+    /// Reload credentials from disk first, then keychain as fallback.
+    /// On macOS, Claude Code may store credentials exclusively in keychain
+    /// (deleting .credentials.json), so we must check both sources.
     func reloadCredentials(completion: @escaping (Bool) -> Void) {
         let previousToken = accessToken
 
-        // Only try the file, not keychain — avoid racing with Claude Code's keychain access
+        // 1. Try file first
         if let data = try? Data(contentsOf: Self.credentialsPath),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let oauth = json["claudeAiOauth"] as? [String: Any],
@@ -113,13 +120,35 @@ class AuthManager: ObservableObject {
             subscriptionType = oauth["subscriptionType"] as? String ?? ""
             credentialSource = .file
             isAuthenticated = true
+            let changed = accessToken != previousToken
+            if changed { Log.info("Credentials reloaded from file") }
+            completion(true)
+            return
         }
 
-        let changed = accessToken != previousToken && isAuthenticated
-        if changed {
-            Log.info("Credentials reloaded from file")
+        // 2. Fallback to keychain (off main thread)
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let keychainJSON = Self.loadFromKeychain()
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if let keychainJSON,
+                   let oauth = keychainJSON["claudeAiOauth"] as? [String: Any],
+                   let token = oauth["accessToken"] as? String, !token.isEmpty {
+                    self.accessToken = token
+                    self.refreshToken = oauth["refreshToken"] as? String
+                    self.tokenExpiresAt = oauth["expiresAt"] as? Double
+                    self.subscriptionType = oauth["subscriptionType"] as? String ?? ""
+                    self.credentialSource = .keychain
+                    self.isAuthenticated = true
+                    let changed = self.accessToken != previousToken
+                    if changed { Log.info("Credentials reloaded from Keychain") }
+                    completion(true)
+                } else {
+                    Log.warn("No credentials found in file or Keychain")
+                    completion(self.isAuthenticated)
+                }
+            }
         }
-        completion(isAuthenticated)
     }
 
     // MARK: - Credentials file watcher

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -277,7 +277,7 @@ struct MenuBarView: View {
                     } else {
                         VStack(alignment: .leading, spacing: 8) {
                             SHBadge(text: "Not connected", color: .orange)
-                            Text("Run `claude login` in Terminal")
+                            Text("Run `claude auth login` in Terminal")
                                 .font(.system(size: 11))
                                 .foregroundColor(.secondary)
                             SHButton(label: "Retry", icon: "arrow.clockwise", style: .outline) {
@@ -1729,7 +1729,7 @@ struct MenuBarView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(error)
                         .font(.system(size: 12, weight: .medium))
-                    Text(isAuth ? "Run `claude login` in Terminal" :
+                    Text(isAuth ? "Run `claude auth login` in Terminal" :
                          isNetwork ? "Check your internet connection" :
                          isRateLimit ? "Will auto-retry shortly" :
                          "Try refreshing or check settings")

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -1185,21 +1185,16 @@ class UsageManager: ObservableObject {
                                 }
                             }
                         }
-                    } else if !self.quotas.isEmpty {
-                        let cooldown = min(retryAfterValue > 0 ? retryAfterValue : 30.0, 60.0)
-                        self.finishLoading()
-                        self.rateLimitedUntil = Date().addingTimeInterval(cooldown)
-                        Log.info("Rate limited (429), keeping existing data, retry in \(Int(cooldown))s")
-                    } else if retryCount < Self.maxRetries {
-                        let delay = 5 * pow(2.0, Double(retryCount))
-                        Log.info("Rate limited (429), retrying in \(Int(delay))s (attempt \(retryCount + 1)/\(Self.maxRetries))...")
-                        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                            self?.fetchUsage(retryCount: retryCount + 1)
-                        }
                     } else {
-                        self.finishLoading(error: "Rate limited — run `claude login` to refresh")
-                        self.rateLimitedUntil = Date().addingTimeInterval(60)
-                        Log.info("Rate limited (429), all retries exhausted, will auto-retry in 60s")
+                        let cooldown = retryAfterValue > 0 ? retryAfterValue : 30.0
+                        self.rateLimitedUntil = Date().addingTimeInterval(cooldown)
+                        if !self.quotas.isEmpty {
+                            self.finishLoading()
+                            Log.info("Rate limited (429), keeping existing data, retry in \(Int(cooldown))s")
+                        } else {
+                            self.finishLoading(error: "Rate limited — retrying in \(Int(cooldown))s")
+                            Log.info("Rate limited (429), no data yet, will auto-retry in \(Int(cooldown))s")
+                        }
                     }
 
                 default:

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -986,6 +986,7 @@ class UsageManager: ObservableObject {
     /// Manual refresh — always clears rate limit cooldown
     func refresh() {
         rateLimitedUntil = nil
+        consecutive429Count = 0
         refreshInternal()
     }
 
@@ -1207,7 +1208,7 @@ class UsageManager: ObservableObject {
                         // When missing/zero, escalate: 30s, 2min, 10min, 30min, 60min, 120min (cap)
                         let cooldown: Double
                         if retryAfterValue > 0 {
-                            cooldown = retryAfterValue
+                            cooldown = min(retryAfterValue, 7200)
                         } else {
                             let steps: [Double] = [30, 120, 600, 1800, 3600, 7200]
                             let index = min(self.consecutive429Count - 1, steps.count - 1)

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -1170,9 +1170,9 @@ class UsageManager: ObservableObject {
                 case 429:
                     let retryAfterHeader = httpResponse.value(forHTTPHeaderField: "Retry-After")
                     let retryAfterValue = retryAfterHeader.flatMap(Double.init) ?? -1
-                    let isLikelyStaleToken = retryAfterValue == 0
 
-                    if isLikelyStaleToken && self.auth.refreshToken != nil && retryCount == 0 {
+                    // Retry-After:0 on first attempt may indicate a stale token — try refreshing once
+                    if retryAfterValue == 0 && self.auth.refreshToken != nil && retryCount == 0 {
                         Log.info("429 with Retry-After:0 — likely stale token, refreshing...")
                         self.auth.reloadCredentials { [weak self] success in
                             guard let self else { return }
@@ -1186,13 +1186,15 @@ class UsageManager: ObservableObject {
                             }
                         }
                     } else {
-                        let cooldown = retryAfterValue > 0 ? retryAfterValue : 30.0
+                        // Respect server's Retry-After; floor at 120s when missing/zero
+                        // to avoid hammering the endpoint in a tight loop
+                        let cooldown = retryAfterValue > 0 ? retryAfterValue : 120.0
                         self.rateLimitedUntil = Date().addingTimeInterval(cooldown)
                         if !self.quotas.isEmpty {
                             self.finishLoading()
                             Log.info("Rate limited (429), keeping existing data, retry in \(Int(cooldown))s")
                         } else {
-                            self.finishLoading(error: "Rate limited — retrying in \(Int(cooldown))s")
+                            self.finishLoading(error: "Rate limited — retrying in \(Int(cooldown / 60))min")
                             Log.info("Rate limited (429), no data yet, will auto-retry in \(Int(cooldown))s")
                         }
                     }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -591,6 +591,7 @@ class UsageManager: ObservableObject {
     private static let statsWindowDays = 30
 
     private var rateLimitedUntil: Date?
+    private var consecutive429Count = 0
     private var countdownTimer: AnyCancellable?
     private var autoRefreshTimer: AnyCancellable?
     private var activeSessionTimer: AnyCancellable?
@@ -1018,7 +1019,7 @@ class UsageManager: ObservableObject {
         }
         guard !isLoading else { return }
         guard isAuthenticated, auth.accessToken != nil else {
-            errorMessage = "Not authenticated — run `claude login` in Terminal"
+            errorMessage = "Not authenticated — run `claude auth login` in Terminal"
             return
         }
 
@@ -1033,7 +1034,7 @@ class UsageManager: ObservableObject {
                     if success { self.fetchUsage() }
                     else {
                         self.isLoading = false
-                        self.errorMessage = "Session expired — run `claude login`"
+                        self.errorMessage = "Session expired — run `claude auth login`"
                     }
                 }
                 return
@@ -1049,7 +1050,7 @@ class UsageManager: ObservableObject {
                 } else {
                     DispatchQueue.main.async {
                         self.isLoading = false
-                        self.errorMessage = "Session expired — run `claude login`"
+                        self.errorMessage = "Session expired — run `claude auth login`"
                     }
                 }
                 // Notify queued callers
@@ -1070,7 +1071,21 @@ class UsageManager: ObservableObject {
         guard let token = auth.accessToken else {
             isLoading = false
             loadingStartedAt = nil
-            errorMessage = "No access token — run `claude login`"
+            errorMessage = "No access token — run `claude auth login`"
+            return
+        }
+
+        if auth.tokenExpired {
+            Log.warn("Token expired, attempting to reload credentials...")
+            auth.reloadCredentials { [weak self] success in
+                guard let self else { return }
+                if success && !self.auth.tokenExpired {
+                    Log.info("Got fresh token, fetching usage...")
+                    self.fetchUsage(retryCount: retryCount)
+                } else {
+                    self.finishLoading(error: "Session expired — run `claude auth login`")
+                }
+            }
             return
         }
 
@@ -1142,6 +1157,7 @@ class UsageManager: ObservableObject {
                     )
                     self.parseUsageResponse(data)
                     self.finishLoading()
+                    self.consecutive429Count = 0
                     self.lastRefresh = Date()
                     self.refreshStats()
                     self.checkNotifications()
@@ -1159,17 +1175,18 @@ class UsageManager: ObservableObject {
                                 self.fetchUsage(retryCount: retryCount + 1)
                             } else {
                                 DispatchQueue.main.async {
-                                    self.finishLoading(error: "Session expired — run `claude login`")
+                                    self.finishLoading(error: "Session expired — run `claude auth login`")
                                 }
                             }
                         }
                     } else {
-                        self.finishLoading(error: "Session expired — run `claude login`")
+                        self.finishLoading(error: "Session expired — run `claude auth login`")
                     }
 
                 case 429:
                     let retryAfterHeader = httpResponse.value(forHTTPHeaderField: "Retry-After")
                     let retryAfterValue = retryAfterHeader.flatMap(Double.init) ?? -1
+                    self.consecutive429Count += 1
 
                     // Retry-After:0 on first attempt may indicate a stale token — try refreshing once
                     if retryAfterValue == 0 && self.auth.refreshToken != nil && retryCount == 0 {
@@ -1181,21 +1198,29 @@ class UsageManager: ObservableObject {
                                 self.fetchUsage(retryCount: retryCount + 1)
                             } else {
                                 DispatchQueue.main.async {
-                                    self.finishLoading(error: "Session expired — run `claude login`")
+                                    self.finishLoading(error: "Session expired — run `claude auth login`")
                                 }
                             }
                         }
                     } else {
-                        // Respect server's Retry-After; floor at 120s when missing/zero
-                        // to avoid hammering the endpoint in a tight loop
-                        let cooldown = retryAfterValue > 0 ? retryAfterValue : 120.0
+                        // Respect server's Retry-After when present.
+                        // When missing/zero, escalate: 30s, 2min, 10min, 30min, 60min, 120min (cap)
+                        let cooldown: Double
+                        if retryAfterValue > 0 {
+                            cooldown = retryAfterValue
+                        } else {
+                            let steps: [Double] = [30, 120, 600, 1800, 3600, 7200]
+                            let index = min(self.consecutive429Count - 1, steps.count - 1)
+                            cooldown = steps[index]
+                        }
                         self.rateLimitedUntil = Date().addingTimeInterval(cooldown)
                         if !self.quotas.isEmpty {
                             self.finishLoading()
                             Log.info("Rate limited (429), keeping existing data, retry in \(Int(cooldown))s")
                         } else {
-                            self.finishLoading(error: "Rate limited — retrying in \(Int(cooldown / 60))min")
-                            Log.info("Rate limited (429), no data yet, will auto-retry in \(Int(cooldown))s")
+                            let display = cooldown >= 60 ? "\(Int(cooldown / 60))min" : "\(Int(cooldown))s"
+                            self.finishLoading(error: "Rate limited — retrying in \(display)")
+                            Log.info("Rate limited (429 #\(self.consecutive429Count)), no data yet, will auto-retry in \(Int(cooldown))s")
                         }
                     }
 


### PR DESCRIPTION
## Summary

Fixes the usage tab getting permanently stuck when the API returns 429.

**Changes:**
- Respect `Retry-After` header instead of capping to 60s (max 2h)
- Escalating backoff when `Retry-After` is 0: 30s → 2min → 10min → 30min → 1h → 2h
- Pre-flight token expiry check before API calls
- `reloadCredentials()` falls back to Keychain when `.credentials.json` is missing
- Error messages updated: `claude login` → `claude auth login`

**Why keychain fallback:** On macOS, [credentials are stored in Keychain, not `.credentials.json`](https://code.claude.com/docs/en/authentication). The file-only reload was a silent no-op. See also [anthropics/claude-code#1414](https://github.com/anthropics/claude-code/issues/1414).

## Test plan

- [x] Expired token → shows error immediately, no API call
- [x] Rate limited → escalating backoff, no retry storm
- [x] Manual Retry resets backoff
- [x] Keychain reload works when `.credentials.json` missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)