### PR TITLE
fix: prevent Usage tab flicker when OAuth token expired

### DIFF
--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -698,7 +698,7 @@ class UsageManager: ObservableObject {
         auth.objectWillChange.sink { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self else { return }
-                if self.isAuthenticated && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
+                if self.isAuthenticated && !self.auth.tokenExpired && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
                     self.showSettings = false
                     self.refresh()
                 }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -698,6 +698,7 @@ class UsageManager: ObservableObject {
         auth.objectWillChange.sink { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self else { return }
+                // tokenExpired guard prevents a flicker loop: fetchUsage -> reloadCredentials -> auth republishes -> sink fires again.
                 if self.isAuthenticated && !self.auth.tokenExpired && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
                     self.showSettings = false
                     self.refresh()


### PR DESCRIPTION
## Summary

Fixes a tight feedback loop that caused the Usage tab to flicker rapidly whenever the OAuth token was expired (i.e. when `claude auth login` was needed).

Apologies — this was surfaced by my previous PR (#6). The buggy sink predates that change, but PR #6 replaced a slow server-401 path with an instant local expiry check, which turned a latent issue into a visible tight loop. Sorry for the churn.

## Root cause

In `Sources/UsageManager.swift`, the auto-reconnect sink on `auth.objectWillChange` (around L698) re-entered `refresh()` whenever `isAuthenticated && !isLoading && (quotas.isEmpty || errorMessage != nil)` — without checking whether the token was expired.

When expired:
1. Sink fires → `refresh()` → `fetchUsage()`
2. `fetchUsage()` sees `auth.tokenExpired` and calls `auth.reloadCredentials(...)`
3. `reloadCredentials` republishes auth changes → sink fires again
4. Loop toggles `isLoading` and resets `errorMessage`, producing visible flicker until the user re-authenticates.

## Fix

Guard the sink with `!auth.tokenExpired` so the auto-reconnect only fires when credentials are actually valid. Once the user re-logs in, the watcher publishes fresh creds, `tokenExpired` becomes `false`, and the sink resumes normally.

Minimal one-line change, same behavior for the happy path.

## Test plan

- [x] `xcodegen generate && xcodebuild -scheme ClaudeGod -configuration Debug build` succeeds
- [ ] Reproduce pre-fix: let token expire (or manually invalidate `~/.claude/.credentials.json`), open Usage tab → observe flicker
- [ ] With fix: same scenario → Usage tab shows stable "Session expired — run `claude auth login`" message
- [ ] After `claude auth login`, Usage tab auto-reconnects and loads quotas