### PR TITLE
fix: prevent Usage tab flicker when OAuth token expired

### DIFF
--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -698,6 +698,8 @@ class UsageManager: ObservableObject {
         auth.objectWillChange.sink { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self else { return }
+                // Don't re-enter refresh loop while token is expired — causes rapid flicker
+                guard !self.auth.tokenExpired else { return }
                 if self.isAuthenticated && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
                     self.showSettings = false
                     self.refresh()


### PR DESCRIPTION
## Problem

When the OAuth token expires, the Usage tab enters a rapid flicker loop that can freeze the entire app.

**Root cause:** The `auth.objectWillChange` sink in `UsageManager.swift` calls `refresh()` whenever auth state changes and `errorMessage != nil`. When the token is expired, `fetchUsage()` detects this and calls `reloadCredentials()`, which publishes an auth change — re-firing the sink — which calls `refresh()` again. The cycle toggles `isLoading` and `errorMessage` continuously, starving the main thread.

**Verified:** With a genuinely expired token, the app becomes completely unresponsive. It only recovers if the underlying token is still valid on Anthropic's servers (in which case an eventual 200 response breaks the loop) — but with a truly expired token it loops forever and requires force-quit.

## Fix

One-line guard in the sink:

```swift
guard !self.auth.tokenExpired else { return }
```

This exits early while the token is expired, stopping the feedback loop entirely. Normal reconnect behaviour (file watcher detecting new credentials) is fully preserved.

## Test plan

- [x] `xcodegen generate && xcodebuild -scheme ClaudeGod -configuration Release build` succeeds
- [x] Pre-fix: writing expired credentials + clicking Refresh causes app to freeze/flicker
- [x] With fix: app shows a steady error message with no flicker
- [x] Post-login: app auto-reconnects after `claude auth login` completes