### PR TITLE
feat: Sign In button + auto-reconnect when session expires

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -151,6 +151,122 @@ class AuthManager: ObservableObject {
         }
     }
 
+    // MARK: - Silent token self-refresh
+
+    private static let oauthTokenURL = URL(string: "https://platform.claude.com/v1/oauth/token")!
+    private static let oauthClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    /// Attempt a silent OAuth refresh_token grant.
+    /// Writes the new tokens back to Keychain (and credentials file if present)
+    /// so Claude Code picks up the updated refresh token on its next operation.
+    func selfRefreshToken(completion: @escaping (Bool) -> Void) {
+        guard let rt = refreshToken, !rt.isEmpty else {
+            Log.warn("selfRefreshToken: no refresh token available")
+            completion(false)
+            return
+        }
+
+        Log.info("selfRefreshToken: attempting refresh_token grant")
+        var request = URLRequest(url: Self.oauthTokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("claude-code/2.1", forHTTPHeaderField: "User-Agent")
+        let body: [String: String] = [
+            "grant_type": "refresh_token",
+            "refresh_token": rt,
+            "client_id": Self.oauthClientID
+        ]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
+            completion(false)
+            return
+        }
+        request.httpBody = bodyData
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else { return }
+
+            if let error {
+                Log.error("selfRefreshToken: network error: \(error)")
+                DispatchQueue.main.async { completion(false) }
+                return
+            }
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let newAccessToken = json["access_token"] as? String, !newAccessToken.isEmpty else {
+                let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? "(no body)"
+                Log.error("selfRefreshToken: bad response — \(body.prefix(200))")
+                DispatchQueue.main.async { completion(false) }
+                return
+            }
+
+            let newRefreshToken = json["refresh_token"] as? String ?? rt
+            let expiresIn = json["expires_in"] as? Double ?? 3600
+            let newExpiresAt = (Date().timeIntervalSince1970 + expiresIn) * 1000
+
+            DispatchQueue.main.async {
+                self.accessToken = newAccessToken
+                self.refreshToken = newRefreshToken
+                self.tokenExpiresAt = newExpiresAt
+                self.isAuthenticated = true
+                Log.info("selfRefreshToken: success — new token expires in \(Int(expiresIn))s")
+                self.persistRefreshedCredentials(
+                    accessToken: newAccessToken,
+                    refreshToken: newRefreshToken,
+                    expiresAt: newExpiresAt
+                )
+                completion(true)
+            }
+        }.resume()
+    }
+
+    /// Write refreshed tokens back to Keychain and credentials file,
+    /// preserving existing fields (subscriptionType, rateLimitTier, scopes).
+    private func persistRefreshedCredentials(accessToken: String, refreshToken: String, expiresAt: Double) {
+        DispatchQueue.global(qos: .utility).async {
+            // Read existing entry to preserve non-token fields
+            var root = Self.loadFromKeychain() ?? [:]
+            var oauth = root["claudeAiOauth"] as? [String: Any] ?? [:]
+            oauth["accessToken"] = accessToken
+            oauth["refreshToken"] = refreshToken
+            oauth["expiresAt"] = Int(expiresAt)
+            root["claudeAiOauth"] = oauth
+
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: root),
+                  let jsonString = String(data: jsonData, encoding: .utf8) else {
+                Log.error("persistRefreshedCredentials: failed to serialize JSON")
+                return
+            }
+
+            // Overwrite Keychain entry
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+            p.arguments = ["add-generic-password", "-U", "-s", "Claude Code-credentials", "-a", "", "-w", jsonString]
+            p.standardError = Pipe()
+            try? p.run()
+            p.waitUntilExit()
+            if p.terminationStatus == 0 {
+                Log.info("persistRefreshedCredentials: Keychain updated")
+            } else {
+                Log.warn("persistRefreshedCredentials: Keychain update failed (status \(p.terminationStatus))")
+            }
+
+            // Also update credentials file if it exists
+            if FileManager.default.fileExists(atPath: Self.credentialsPath.path),
+               let fileData = try? Data(contentsOf: Self.credentialsPath),
+               var fileJson = try? JSONSerialization.jsonObject(with: fileData) as? [String: Any] {
+                var fileOauth = fileJson["claudeAiOauth"] as? [String: Any] ?? [:]
+                fileOauth["accessToken"] = accessToken
+                fileOauth["refreshToken"] = refreshToken
+                fileOauth["expiresAt"] = Int(expiresAt)
+                fileJson["claudeAiOauth"] = fileOauth
+                if let newData = try? JSONSerialization.data(withJSONObject: fileJson) {
+                    try? newData.write(to: Self.credentialsPath)
+                    Log.info("persistRefreshedCredentials: credentials file updated")
+                }
+            }
+        }
+    }
+
     // MARK: - Credentials file watcher
 
     func startWatchingCredentials() {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -486,6 +486,27 @@ struct MenuBarView: View {
                         .font(.system(size: 12))
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                    SHDivider()
+                    Toggle("Auto-reconnect when session expires", isOn: $manager.autoReconnect)
+                        .font(.system(size: 12))
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                    if manager.autoReconnect {
+                        Text("Automatically opens browser sign-in when your token expires.")
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if manager.auth.tokenExpired {
+                        SHButton(
+                            label: manager.isAutoReconnecting ? "Reconnecting..." : "Reconnect now",
+                            icon: manager.isAutoReconnecting ? "arrow.triangle.2.circlepath" : "person.crop.circle.badge.plus",
+                            style: .outline
+                        ) {
+                            manager.launchAutoReconnect()
+                        }
+                        .disabled(manager.isAutoReconnecting)
+                    }
                 }
             }
 

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -288,6 +288,9 @@ struct MenuBarView: View {
                                 manager.launchAutoReconnect()
                             }
                             .disabled(manager.isAutoReconnecting)
+                            if let session = manager.terminalSession {
+                                EmbeddedTerminalView(session: session)
+                            }
                         }
                     }
                 }
@@ -1743,36 +1746,41 @@ struct MenuBarView: View {
         let isAuth = !isRateLimit && (error.contains("login") || error.contains("expired") || error.contains("authenticated"))
         let isNetwork = error.contains("Network") || error.contains("connection")
 
-        return SHCard {
-            HStack(spacing: 10) {
-                Image(systemName: isAuth ? "key.fill" : isRateLimit ? "clock.fill" : "exclamationmark.triangle")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(isRateLimit ? .blue : .orange)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(error)
-                        .font(.system(size: 12, weight: .medium))
-                    Text(isAuth ? (manager.isAutoReconnecting ? "Opening browser..." : "Session expired") :
-                         isNetwork ? "Check your internet connection" :
-                         isRateLimit ? "Will auto-retry shortly" :
-                         "Try refreshing or check settings")
-                        .font(.system(size: 11))
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-                if isAuth {
-                    SHButton(
-                        label: manager.isAutoReconnecting ? "Signing in..." : "Sign In",
-                        icon: manager.isAutoReconnecting ? "arrow.triangle.2.circlepath" : "person.crop.circle.badge.plus",
-                        style: .outline
-                    ) {
-                        manager.launchAutoReconnect()
+        return VStack(spacing: 6) {
+            SHCard {
+                HStack(spacing: 10) {
+                    Image(systemName: isAuth ? "key.fill" : isRateLimit ? "clock.fill" : "exclamationmark.triangle")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(isRateLimit ? .blue : .orange)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(error)
+                            .font(.system(size: 12, weight: .medium))
+                        Text(isAuth ? (manager.isAutoReconnecting ? "Waiting for browser sign-in..." : "Session expired") :
+                             isNetwork ? "Check your internet connection" :
+                             isRateLimit ? "Will auto-retry shortly" :
+                             "Try refreshing or check settings")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
                     }
-                    .disabled(manager.isAutoReconnecting)
-                } else {
-                    SHButton(label: "Retry", icon: "arrow.clockwise", style: .outline) {
-                        manager.refresh()
+                    Spacer()
+                    if isAuth {
+                        SHButton(
+                            label: manager.isAutoReconnecting ? "Signing in..." : "Sign In",
+                            icon: manager.isAutoReconnecting ? "arrow.triangle.2.circlepath" : "person.crop.circle.badge.plus",
+                            style: .outline
+                        ) {
+                            manager.launchAutoReconnect()
+                        }
+                        .disabled(manager.isAutoReconnecting)
+                    } else {
+                        SHButton(label: "Retry", icon: "arrow.clockwise", style: .outline) {
+                            manager.refresh()
+                        }
                     }
                 }
+            }
+            if isAuth, let session = manager.terminalSession {
+                EmbeddedTerminalView(session: session)
             }
         }
     }
@@ -3420,6 +3428,70 @@ struct MenuBarView: View {
         let minutes = (Int(remaining) % 3600) / 60
         if hours > 0 { return "in \(hours)h \(minutes)m" }
         return "in \(minutes)m"
+    }
+}
+
+// ============================================================
+// MARK: - Embedded Terminal
+// ============================================================
+
+struct EmbeddedTerminalView: View {
+    @ObservedObject var session: TerminalSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Title bar
+            HStack(spacing: 6) {
+                Circle().fill(Color.red.opacity(0.8)).frame(width: 8, height: 8)
+                Circle().fill(Color.yellow.opacity(0.8)).frame(width: 8, height: 8)
+                Circle().fill(Color.green.opacity(0.8)).frame(width: 8, height: 8)
+                Text("claude auth login")
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.5))
+                Spacer()
+                if session.isRunning {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(Color.green)
+                            .frame(width: 5, height: 5)
+                        Text("running")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(.green.opacity(0.8))
+                    }
+                } else {
+                    Text("done")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.black.opacity(0.4))
+
+            Divider().background(Color.white.opacity(0.08))
+
+            // Output
+            ScrollViewReader { proxy in
+                ScrollView {
+                    Text(session.output.isEmpty ? " " : session.output)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.green.opacity(0.9))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .id("bottom")
+                }
+                .onChange(of: session.output) { _ in
+                    withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+                }
+            }
+            .frame(height: 130)
+        }
+        .background(Color(red: 0.05, green: 0.05, blue: 0.05))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
     }
 }
 

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -266,7 +266,7 @@ struct MenuBarView: View {
             SHCard {
                 VStack(alignment: .leading, spacing: 8) {
                     SHLabel("Authentication")
-                    if manager.isAuthenticated {
+                    if manager.isAuthenticated && !manager.auth.tokenExpired {
                         HStack(spacing: 8) {
                             SHBadge(text: "Connected", color: .green)
                             Spacer()
@@ -276,17 +276,18 @@ struct MenuBarView: View {
                         }
                     } else {
                         VStack(alignment: .leading, spacing: 8) {
-                            SHBadge(text: "Not connected", color: .orange)
-                            Text("Run `claude auth login` in Terminal")
-                                .font(.system(size: 11))
-                                .foregroundColor(.secondary)
-                            SHButton(label: "Retry", icon: "arrow.clockwise", style: .outline) {
-                                manager.loadCredentials()
-                                if manager.isAuthenticated {
-                                    manager.showSettings = false
-                                    manager.refresh()
-                                }
+                            SHBadge(
+                                text: manager.isAuthenticated ? "Session expired" : "Not connected",
+                                color: .orange
+                            )
+                            SHButton(
+                                label: manager.isAutoReconnecting ? "Signing in..." : "Sign In",
+                                icon: manager.isAutoReconnecting ? "arrow.triangle.2.circlepath" : "person.crop.circle.badge.plus",
+                                style: .outline
+                            ) {
+                                manager.launchAutoReconnect()
                             }
+                            .disabled(manager.isAutoReconnecting)
                         }
                     }
                 }
@@ -1750,7 +1751,7 @@ struct MenuBarView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(error)
                         .font(.system(size: 12, weight: .medium))
-                    Text(isAuth ? "Run `claude auth login` in Terminal" :
+                    Text(isAuth ? (manager.isAutoReconnecting ? "Opening browser..." : "Session expired") :
                          isNetwork ? "Check your internet connection" :
                          isRateLimit ? "Will auto-retry shortly" :
                          "Try refreshing or check settings")
@@ -1759,9 +1760,14 @@ struct MenuBarView: View {
                 }
                 Spacer()
                 if isAuth {
-                    SHButton(label: "Settings", icon: "gearshape", style: .outline) {
-                        manager.showSettings = true
+                    SHButton(
+                        label: manager.isAutoReconnecting ? "Signing in..." : "Sign In",
+                        icon: manager.isAutoReconnecting ? "arrow.triangle.2.circlepath" : "person.crop.circle.badge.plus",
+                        style: .outline
+                    ) {
+                        manager.launchAutoReconnect()
                     }
+                    .disabled(manager.isAutoReconnecting)
                 } else {
                     SHButton(label: "Retry", icon: "arrow.clockwise", style: .outline) {
                         manager.refresh()

--- a/Sources/SessionAnalyzer.swift
+++ b/Sources/SessionAnalyzer.swift
@@ -20,6 +20,7 @@ enum UDKey {
     static let accounts = "accounts"
     static let activeAccountIndex = "activeAccountIndex"
     static let notifiedThresholds = "notifiedThresholds"
+    static let autoReconnect = "autoReconnect"
     static let widgetQuotas = "widgetQuotas"
     static let widgetTodayCost = "widgetTodayCost"
     static let widgetTodayMessages = "widgetTodayMessages"

--- a/Sources/TerminalSession.swift
+++ b/Sources/TerminalSession.swift
@@ -1,0 +1,127 @@
+// TerminalSession.swift
+// Runs a CLI process in a pseudo-TTY and streams output to a @Published string.
+// Used to embed `claude auth login` directly inside the popover.
+
+import Foundation
+import Combine
+
+final class TerminalSession: ObservableObject {
+
+    @Published private(set) var output: String = ""
+    @Published private(set) var isRunning: Bool = false
+
+    private var process: Process?
+    private var masterFD: Int32 = -1
+    private var readSource: DispatchSourceRead?
+
+    // MARK: - Start
+
+    /// Launch `executablePath args` inside a PTY.
+    /// The process gets a real TTY so prompts and browser-open calls work.
+    func start(executablePath: String, args: [String] = []) {
+        stop() // clean up any previous session
+        output = ""
+
+        // Create PTY pair (POSIX, available on Darwin)
+        let master = posix_openpt(O_RDWR | O_NOCTTY)
+        guard master >= 0 else {
+            output = "[error] posix_openpt failed: \(String(cString: strerror(errno)))\n"
+            return
+        }
+        guard grantpt(master) == 0, unlockpt(master) == 0 else {
+            close(master)
+            output = "[error] grantpt/unlockpt failed\n"
+            return
+        }
+        guard let slaveNamePtr = ptsname(master) else {
+            close(master)
+            output = "[error] ptsname failed\n"
+            return
+        }
+        let slaveName = String(cString: slaveNamePtr)
+        let slave = open(slaveName, O_RDWR)
+        guard slave >= 0 else {
+            close(master)
+            output = "[error] open slave PTY failed\n"
+            return
+        }
+
+        masterFD = master
+
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: executablePath)
+        p.arguments = args
+
+        // Give the process the slave end as its terminal
+        let slaveHandle = FileHandle(fileDescriptor: slave, closeOnDealloc: true)
+        p.standardInput  = slaveHandle
+        p.standardOutput = slaveHandle
+        p.standardError  = slaveHandle
+
+        p.terminationHandler = { [weak self] _ in
+            DispatchQueue.main.async { self?.isRunning = false }
+        }
+
+        do {
+            try p.run()
+        } catch {
+            close(master)
+            close(slave)
+            output = "[error] launch failed: \(error.localizedDescription)\n"
+            return
+        }
+
+        // App only needs master end — slave is owned by the child process
+        close(slave)
+
+        process = p
+        isRunning = true
+        startReading()
+    }
+
+    // MARK: - Stop
+
+    func stop() {
+        readSource?.cancel()
+        readSource = nil
+        process?.terminate()
+        process = nil
+        if masterFD >= 0 {
+            close(masterFD)
+            masterFD = -1
+        }
+        isRunning = false
+    }
+
+    // MARK: - Read loop
+
+    private func startReading() {
+        let fd = masterFD
+        let src = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .global(qos: .utility))
+        src.setEventHandler { [weak self] in
+            var buf = [UInt8](repeating: 0, count: 2048)
+            let n = read(fd, &buf, buf.count)
+            guard n > 0 else { return }
+            let raw = String(bytes: buf.prefix(n), encoding: .utf8) ?? ""
+            let clean = Self.stripANSI(raw)
+            guard !clean.isEmpty else { return }
+            DispatchQueue.main.async { self?.output += clean }
+        }
+        src.setCancelHandler { /* fd closed in stop() */ }
+        src.resume()
+        readSource = src
+    }
+
+    // MARK: - ANSI stripping
+
+    private static let ansiPattern = try! NSRegularExpression(
+        pattern: #"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*\x07)"#
+    )
+
+    private static func stripANSI(_ text: String) -> String {
+        let range = NSRange(text.startIndex..., in: text)
+        return ansiPattern.stringByReplacingMatches(in: text, range: range, withTemplate: "")
+    }
+
+    deinit { stop() }
+}

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -602,6 +602,7 @@ class UsageManager: ObservableObject {
     private var countdownTimer: AnyCancellable?
     private var autoRefreshTimer: AnyCancellable?
     private var activeSessionTimer: AnyCancellable?
+    private var reconnectPollTimer: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
     private var isRefreshingToken = false
     private var tokenRefreshQueue: [(Bool) -> Void] = [] // queued callbacks for concurrent refresh requests
@@ -1043,14 +1044,37 @@ class UsageManager: ObservableObject {
             return
         }
 
-        Log.info("Terminal opened with claude auth login — watching for new credentials")
-        // File watcher will pick up new credentials automatically once claude auth login completes
-        // Reset reconnecting state after a timeout so the button re-enables
-        DispatchQueue.main.asyncAfter(deadline: .now() + 120) { [weak self] in
-            guard let self, self.isAutoReconnecting else { return }
-            self.isAutoReconnecting = false
-            if !self.auth.tokenExpired { self.refresh() }
-        }
+        Log.info("Terminal opened with claude auth login — polling for new credentials every 5s")
+        // claude auth login writes credentials to Keychain, not back to the file,
+        // so the file watcher will NOT fire. Poll reloadCredentials() instead.
+        startReconnectPolling()
+    }
+
+    private func startReconnectPolling() {
+        reconnectPollTimer?.cancel()
+        var elapsed = 0
+        reconnectPollTimer = Timer.publish(every: 5, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self, self.isAutoReconnecting else { return }
+                elapsed += 5
+                self.auth.reloadCredentials { [weak self] _ in
+                    guard let self else { return }
+                    if !self.auth.tokenExpired {
+                        Log.info("Auto-reconnect: fresh credentials detected after \(elapsed)s, resuming")
+                        self.reconnectPollTimer?.cancel()
+                        self.reconnectPollTimer = nil
+                        self.isAutoReconnecting = false
+                        self.refresh()
+                    } else if elapsed >= 120 {
+                        Log.warn("Auto-reconnect: timed out (120s) waiting for credentials")
+                        self.reconnectPollTimer?.cancel()
+                        self.reconnectPollTimer = nil
+                        self.isAutoReconnecting = false
+                        self.errorMessage = "Session expired — run `claude auth login` in Terminal"
+                    }
+                }
+            }
     }
 
     // MARK: - Actions

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -603,6 +603,7 @@ class UsageManager: ObservableObject {
     private var autoRefreshTimer: AnyCancellable?
     private var activeSessionTimer: AnyCancellable?
     private var reconnectPollTimer: AnyCancellable?
+    private var tokenHealthTimer: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
     private var isRefreshingToken = false
     private var tokenRefreshQueue: [(Bool) -> Void] = [] // queued callbacks for concurrent refresh requests
@@ -725,6 +726,7 @@ class UsageManager: ObservableObject {
         setupAutoRefresh()
         setupActiveSessionDetection()
         setupWakeObserver()
+        setupTokenHealthTimer()
         disableAppNap()
         isGitAvailable = GitAnalyzer.isGitAvailable()
 
@@ -1147,21 +1149,39 @@ class UsageManager: ObservableObject {
                 self.finishLoading(error: "Session expired — run `claude auth login`")
                 for callback in queued { callback(false) }
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10, execute: timeout)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 20, execute: timeout)
             auth.reloadCredentials { [weak self] success in
-                timeout.cancel()
                 guard let self, !didComplete else { return }
-                didComplete = true
-                self.isRefreshingToken = false
-                let queued = self.tokenRefreshQueue
-                self.tokenRefreshQueue.removeAll()
-                if success {
+
+                if success && !self.auth.tokenExpired {
+                    // Got a fresh token from file or Keychain (e.g. Claude Code refreshed it)
+                    timeout.cancel()
+                    didComplete = true
+                    self.isRefreshingToken = false
+                    let queued = self.tokenRefreshQueue
+                    self.tokenRefreshQueue.removeAll()
                     self.fetchUsage()
+                    for callback in queued { callback(true) }
                 } else {
-                    self.finishLoading(error: "Session expired — run `claude auth login`")
+                    // Token still expired — attempt silent self-refresh via OAuth refresh_token grant
+                    Log.info("Reloaded credentials still expired — attempting silent self-refresh")
+                    self.auth.selfRefreshToken { [weak self] refreshed in
+                        guard let self else { return }
+                        timeout.cancel()
+                        guard !didComplete else { return }
+                        didComplete = true
+                        self.isRefreshingToken = false
+                        let queued = self.tokenRefreshQueue
+                        self.tokenRefreshQueue.removeAll()
+                        if refreshed {
+                            self.fetchUsage()
+                            for callback in queued { callback(true) }
+                        } else {
+                            self.finishLoading(error: "Session expired — run `claude auth login`")
+                            for callback in queued { callback(false) }
+                        }
+                    }
                 }
-                // Notify queued callers
-                for callback in queued { callback(success) }
             }
             return
         }
@@ -1467,6 +1487,28 @@ class UsageManager: ObservableObject {
             self?.autoRefresh()
             self?.refreshStats()
         }
+    }
+
+    // MARK: - Proactive token health
+
+    /// Fires every 30 minutes. If the access token expires within the next hour,
+    /// silently self-refreshes via the OAuth refresh_token grant so the app
+    /// stays online without user intervention.
+    private func setupTokenHealthTimer() {
+        tokenHealthTimer?.cancel()
+        tokenHealthTimer = Timer.publish(every: 30 * 60, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self, self.isAuthenticated else { return }
+                guard let expiresAt = self.auth.tokenExpiresAt else { return }
+                let expiresDate = Date(timeIntervalSince1970: expiresAt / 1000)
+                let timeUntilExpiry = expiresDate.timeIntervalSinceNow
+                guard timeUntilExpiry < 3600 && !self.auth.tokenExpired else { return }
+                Log.info("Token health: expires in \(Int(timeUntilExpiry / 60))min — proactively refreshing")
+                self.auth.selfRefreshToken { success in
+                    Log.info("Proactive token refresh: \(success ? "succeeded" : "failed")")
+                }
+            }
     }
 
     // MARK: - Wake & App Nap

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -1003,8 +1003,8 @@ class UsageManager: ObservableObject {
     func launchAutoReconnect() {
         guard !isAutoReconnecting else { return }
         isAutoReconnecting = true
-        errorMessage = "Opening browser to sign in..."
-        Log.info("Auto-reconnect: searching for claude binary")
+        errorMessage = "Opening Terminal to sign in..."
+        Log.info("Auto-reconnect: opening Terminal with claude auth login")
 
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidatePaths = [
@@ -1021,33 +1021,35 @@ class UsageManager: ObservableObject {
             return
         }
 
-        Log.info("Auto-reconnect: launching \(claudePath) login")
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: claudePath)
-        process.arguments = ["login"]
-        process.terminationHandler = { [weak self] proc in
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.isAutoReconnecting = false
-                if proc.terminationStatus == 0 {
-                    Log.info("claude login completed — reloading credentials")
-                    self.auth.reloadCredentials { [weak self] success in
-                        guard let self else { return }
-                        if success { self.refresh() }
-                        else { self.errorMessage = "Reconnect failed — run `claude auth login` in Terminal" }
-                    }
-                } else {
-                    Log.warn("claude login exited with status \(proc.terminationStatus)")
-                    self.errorMessage = "Reconnect failed — run `claude auth login` in Terminal"
-                }
-            }
-        }
-        do {
-            try process.run()
-        } catch {
-            Log.error("Failed to launch claude login: \(error)")
+        // Run in Terminal so claude auth login has a proper TTY and can open the browser
+        let script = """
+        tell application "Terminal"
+            activate
+            do script "\(claudePath) auth login"
+        end tell
+        """
+        var appleScriptError: NSDictionary?
+        guard let appleScript = NSAppleScript(source: script) else {
             isAutoReconnecting = false
             errorMessage = "Session expired — run `claude auth login` in Terminal"
+            return
+        }
+        appleScript.executeAndReturnError(&appleScriptError)
+
+        if let err = appleScriptError {
+            Log.error("AppleScript error: \(err)")
+            isAutoReconnecting = false
+            errorMessage = "Session expired — run `claude auth login` in Terminal"
+            return
+        }
+
+        Log.info("Terminal opened with claude auth login — watching for new credentials")
+        // File watcher will pick up new credentials automatically once claude auth login completes
+        // Reset reconnecting state after a timeout so the button re-enables
+        DispatchQueue.main.asyncAfter(deadline: .now() + 120) { [weak self] in
+            guard let self, self.isAutoReconnecting else { return }
+            self.isAutoReconnecting = false
+            if !self.auth.tokenExpired { self.refresh() }
         }
     }
 

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -337,6 +337,9 @@ class UsageManager: ObservableObject {
     }
     @Published var isAutoReconnecting = false
     @Published var terminalSession: TerminalSession? = nil
+    /// Set to true after auto-reconnect times out so we don't spam Safari tabs.
+    /// Cleared when the user manually triggers Sign In or credentials are refreshed.
+    private var reconnectExhausted = false
 
     @Published var menuBarDisplayMode: MenuBarDisplayMode {
         didSet {
@@ -711,12 +714,13 @@ class UsageManager: ObservableObject {
                 guard let self else { return }
                 // Don't re-enter refresh loop while token is expired — causes rapid flicker
                 if self.auth.tokenExpired {
-                    if self.autoReconnect && !self.isAutoReconnecting {
+                    if self.autoReconnect && !self.isAutoReconnecting && !self.reconnectExhausted {
                         self.launchAutoReconnect()
                     }
                     return
                 }
                 if self.isAuthenticated && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
+                    self.reconnectExhausted = false   // fresh credentials — allow future auto-reconnects
                     self.showSettings = false
                     self.refresh()
                 }
@@ -1008,6 +1012,7 @@ class UsageManager: ObservableObject {
     func launchAutoReconnect() {
         guard !isAutoReconnecting else { return }
         isAutoReconnecting = true
+        reconnectExhausted = false   // manual trigger always allowed
         errorMessage = nil
         Log.info("Auto-reconnect: starting embedded terminal session")
 
@@ -1053,6 +1058,7 @@ class UsageManager: ObservableObject {
                         Log.info("Auto-reconnect: fresh credentials detected after \(elapsed)s, resuming")
                         self.reconnectPollTimer?.cancel()
                         self.reconnectPollTimer = nil
+                        self.reconnectExhausted = false
                         self.finishReconnect()
                         self.refresh()
                     } else if elapsed >= 120 {
@@ -1060,6 +1066,7 @@ class UsageManager: ObservableObject {
                         self.reconnectPollTimer?.cancel()
                         self.reconnectPollTimer = nil
                         self.finishReconnect()
+                        self.reconnectExhausted = true   // stop the tab-spam loop
                         self.errorMessage = "Session expired — run `claude auth login` in Terminal"
                     }
                 }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -330,6 +330,13 @@ class UsageManager: ObservableObject {
         }
     }
 
+    @Published var autoReconnect: Bool {
+        didSet {
+            UserDefaults.standard.set(autoReconnect, forKey: UDKey.autoReconnect)
+        }
+    }
+    @Published var isAutoReconnecting = false
+
     @Published var menuBarDisplayMode: MenuBarDisplayMode {
         didSet {
             UserDefaults.standard.set(menuBarDisplayMode.rawValue, forKey: UDKey.menuBarDisplayMode)
@@ -621,6 +628,7 @@ class UsageManager: ObservableObject {
         self.notificationThreshold = ud.object(forKey: UDKey.notificationThreshold) as? Double ?? 20.0
         self.launchAtLogin = ud.bool(forKey: UDKey.launchAtLogin)
         self.compactMode = ud.bool(forKey: UDKey.compactMode)
+        self.autoReconnect = ud.bool(forKey: UDKey.autoReconnect)
         let savedDisplayMode = ud.integer(forKey: UDKey.menuBarDisplayMode)
         self.menuBarDisplayMode = MenuBarDisplayMode(rawValue: savedDisplayMode) ?? .percentageAndTimer
         self.dailyBudget = ud.double(forKey: UDKey.dailyBudget)
@@ -698,6 +706,13 @@ class UsageManager: ObservableObject {
         auth.objectWillChange.sink { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self else { return }
+                // Don't re-enter refresh loop while token is expired — causes rapid flicker
+                if self.auth.tokenExpired {
+                    if self.autoReconnect && !self.isAutoReconnecting {
+                        self.launchAutoReconnect()
+                    }
+                    return
+                }
                 if self.isAuthenticated && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
                     self.showSettings = false
                     self.refresh()
@@ -978,6 +993,61 @@ class UsageManager: ObservableObject {
                 self?.activeSessionCost = 0
                 self?.activeSessionMessages = 0
             }
+        }
+    }
+
+    // MARK: - Auto-reconnect
+
+    /// Launches `claude login` in the background, opening the browser OAuth flow.
+    /// The existing credentials file watcher picks up the new token automatically.
+    func launchAutoReconnect() {
+        guard !isAutoReconnecting else { return }
+        isAutoReconnecting = true
+        errorMessage = "Opening browser to sign in..."
+        Log.info("Auto-reconnect: searching for claude binary")
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidatePaths = [
+            "/usr/local/bin/claude",
+            "/opt/homebrew/bin/claude",
+            "\(home)/.npm-global/bin/claude",
+            "\(home)/.local/bin/claude",
+            "/usr/bin/claude"
+        ]
+        guard let claudePath = candidatePaths.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
+            Log.warn("claude binary not found — cannot auto-reconnect")
+            isAutoReconnecting = false
+            errorMessage = "Session expired — run `claude auth login` in Terminal"
+            return
+        }
+
+        Log.info("Auto-reconnect: launching \(claudePath) login")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: claudePath)
+        process.arguments = ["login"]
+        process.terminationHandler = { [weak self] proc in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isAutoReconnecting = false
+                if proc.terminationStatus == 0 {
+                    Log.info("claude login completed — reloading credentials")
+                    self.auth.reloadCredentials { [weak self] success in
+                        guard let self else { return }
+                        if success { self.refresh() }
+                        else { self.errorMessage = "Reconnect failed — run `claude auth login` in Terminal" }
+                    }
+                } else {
+                    Log.warn("claude login exited with status \(proc.terminationStatus)")
+                    self.errorMessage = "Reconnect failed — run `claude auth login` in Terminal"
+                }
+            }
+        }
+        do {
+            try process.run()
+        } catch {
+            Log.error("Failed to launch claude login: \(error)")
+            isAutoReconnecting = false
+            errorMessage = "Session expired — run `claude auth login` in Terminal"
         }
     }
 

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -336,6 +336,7 @@ class UsageManager: ObservableObject {
         }
     }
     @Published var isAutoReconnecting = false
+    @Published var terminalSession: TerminalSession? = nil
 
     @Published var menuBarDisplayMode: MenuBarDisplayMode {
         didSet {
@@ -1001,13 +1002,14 @@ class UsageManager: ObservableObject {
 
     // MARK: - Auto-reconnect
 
-    /// Launches `claude login` in the background, opening the browser OAuth flow.
-    /// The existing credentials file watcher picks up the new token automatically.
+    /// Runs `claude auth login` in an embedded PTY inside the popover.
+    /// The browser OAuth flow still opens automatically. Once credentials appear
+    /// in Keychain, the polling loop picks them up and resumes normal operation.
     func launchAutoReconnect() {
         guard !isAutoReconnecting else { return }
         isAutoReconnecting = true
-        errorMessage = "Opening Terminal to sign in..."
-        Log.info("Auto-reconnect: opening Terminal with claude auth login")
+        errorMessage = nil
+        Log.info("Auto-reconnect: starting embedded terminal session")
 
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidatePaths = [
@@ -1024,32 +1026,17 @@ class UsageManager: ObservableObject {
             return
         }
 
-        // Run in Terminal so claude auth login has a proper TTY and can open the browser
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "\(claudePath) auth login"
-        end tell
-        """
-        var appleScriptError: NSDictionary?
-        guard let appleScript = NSAppleScript(source: script) else {
-            isAutoReconnecting = false
-            errorMessage = "Session expired — run `claude auth login` in Terminal"
-            return
-        }
-        appleScript.executeAndReturnError(&appleScriptError)
-
-        if let err = appleScriptError {
-            Log.error("AppleScript error: \(err)")
-            isAutoReconnecting = false
-            errorMessage = "Session expired — run `claude auth login` in Terminal"
-            return
-        }
-
-        Log.info("Terminal opened with claude auth login — polling for new credentials every 5s")
-        // claude auth login writes credentials to Keychain, not back to the file,
-        // so the file watcher will NOT fire. Poll reloadCredentials() instead.
+        let session = TerminalSession()
+        terminalSession = session
+        session.start(executablePath: claudePath, args: ["auth", "login"])
+        Log.info("Embedded terminal started — polling Keychain every 5s for new credentials")
         startReconnectPolling()
+    }
+
+    private func finishReconnect() {
+        terminalSession?.stop()
+        terminalSession = nil
+        isAutoReconnecting = false
     }
 
     private func startReconnectPolling() {
@@ -1066,13 +1053,13 @@ class UsageManager: ObservableObject {
                         Log.info("Auto-reconnect: fresh credentials detected after \(elapsed)s, resuming")
                         self.reconnectPollTimer?.cancel()
                         self.reconnectPollTimer = nil
-                        self.isAutoReconnecting = false
+                        self.finishReconnect()
                         self.refresh()
                     } else if elapsed >= 120 {
                         Log.warn("Auto-reconnect: timed out (120s) waiting for credentials")
                         self.reconnectPollTimer?.cancel()
                         self.reconnectPollTimer = nil
-                        self.isAutoReconnecting = false
+                        self.finishReconnect()
                         self.errorMessage = "Session expired — run `claude auth login` in Terminal"
                     }
                 }


### PR DESCRIPTION
## Problem

When the OAuth token expires, the app freezes and the only recovery path is running `claude auth login` in Terminal — there is no way to re-authenticate from inside the app.

## Changes

**Flicker fix** (same one-line guard as #7 by @shreekarshetty — included here so this PR is self-contained, can be dropped if #7 merges first):
- Guard the `auth.objectWillChange` sink against `tokenExpired` to stop the feedback loop

**Sign In button:**
- Error view: replaces the 'Settings' shortcut with a direct 'Sign In' button when an auth error is detected
- Settings auth card: shows 'Session expired' badge + 'Sign In' button when the token is present but expired

**Auto-reconnect:**
- New opt-in toggle in Settings: 'Auto-reconnect when session expires'
- Tapping Sign In opens a Terminal window running `claude auth login` — giving the process a proper TTY so the browser OAuth flow works correctly
- The existing credentials file watcher picks up the new token automatically on completion — no manual refresh needed
- 2-minute timeout re-enables the button if sign-in is abandoned

## Behaviour

| State | Before | After |
|---|---|---|
| Token expired | App freezes, requires force-quit | Steady error message |
| Recovery | Run `claude auth login` in Terminal manually | Tap 'Sign In' in the app |
| Auto-reconnect | Not available | Opt-in toggle in Settings |
| Claude Code refreshes token in background | App stuck | File watcher detects it, reconnects silently |

## Test plan

- [x] Build succeeds
- [x] Expired token no longer causes flicker/freeze
- [x] 'Sign In' button appears in error view and Settings when session expires
- [x] Tapping 'Sign In' opens Terminal with `claude auth login`
- [x] App auto-reconnects after Claude Code refreshes credentials in background