### PR TITLE
fix: register widget extension by adding NSExtension to Info.plist (#13)

### DIFF
--- a/Widget/Info.plist
+++ b/Widget/Info.plist
@@ -18,5 +18,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -54,6 +54,8 @@ targets:
       properties:
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.lcharvol.claude-god.widget


### PR DESCRIPTION
Closes #13.

## Problem

The widget bundle has shipped since v2.8.0 with no `NSExtension` dict in its `Info.plist`. macOS uses `NSExtensionPointIdentifier` to know an `.appex` is a WidgetKit extension; without it `pluginkit` doesn't list the bundle and the widget never appears in the macOS widget gallery.

## Reproduction (on installed v2.21.0)

\`\`\`bash
$ plutil -p '/Applications/Claude God.app/Contents/PlugIns/ClaudeGodWidget.appex/Contents/Info.plist' | grep -i nsextension
# → no match

$ pluginkit -m -p com.apple.widgetkit-extension | grep -i claude
# → no match
\`\`\`

## Root cause

The widget target's `info.properties` block in `project.yml` only declared version keys, so xcodegen emitted a baseline `Info.plist` without the extension-point pointer. The build then packaged that incomplete plist into `ClaudeGodWidget.appex` — but macOS won't register an extension that doesn't declare which extension point it implements.

## Fix

Added `NSExtensionPointIdentifier: com.apple.widgetkit-extension` under `NSExtension` in `project.yml`. xcodegen now regenerates `Widget/Info.plist` with the dict, and the built `.appex` carries it through.

`NSExtensionPrincipalClass` is **not** needed — the `@main` attribute on the `ClaudeGodWidget: Widget` struct already provides WidgetKit's entry point.

## Verification

\`\`\`bash
$ plutil -p ClaudeGodWidget.appex/Contents/Info.plist | grep -A2 NSExtension
  "NSExtension" => {
    "NSExtensionPointIdentifier" => "com.apple.widgetkit-extension"
  }
\`\`\`

## Test plan

- [ ] After install: \`pluginkit -m -p com.apple.widgetkit-extension | grep -i claude\` lists `com.lcharvol.claude-god.widget`
- [ ] Widget appears in the macOS widget gallery (Notification Center → Edit Widgets → search "Claude God")
- [ ] Adding the widget to the desktop shows the quota gauges
- [ ] Quota updates propagate from the host app to the widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)