### PR TITLE
fix: resizable popover actually responds to user drag

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -82,7 +82,8 @@ struct MenuBarView: View {
                 .padding(.vertical, 12)
             }
             .frame(minHeight: 0, maxHeight: .infinity)
-            .background(WindowResizer(windowHeight: $manager.windowHeight))
+
+            ResizeHandle(height: $manager.windowHeight, minHeight: 400, maxHeight: 1400)
 
             SHDivider()
 
@@ -3969,43 +3970,45 @@ struct HeatmapGrid: View {
     }
 }
 
-// MARK: - Window resizer
+// MARK: - Resize handle
 
-/// Makes the MenuBarExtra window resizable by the user and persists the height.
-struct WindowResizer: NSViewRepresentable {
-    @Binding var windowHeight: Double
+/// A small drag handle inserted into the popover layout. SwiftUI's `.frame(height:)`
+/// already drives the MenuBarExtra(.window) panel height, so dragging this handle
+/// makes the popover grow / shrink directly — no NSWindow style-mask hackery.
+struct ResizeHandle: View {
+    @Binding var height: Double
+    let minHeight: Double
+    let maxHeight: Double
 
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        DispatchQueue.main.async {
-            guard let window = view.window else { return }
-            window.styleMask.insert(.resizable)
-            window.minSize = NSSize(width: 300, height: 400)
-            window.maxSize = NSSize(width: 600, height: 1400)
-            // Allow window to shrink below content's natural height so scrolling kicks in
-            window.contentView?.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-            window.contentView?.setContentHuggingPriority(.defaultLow, for: .vertical)
-            NotificationCenter.default.addObserver(
-                context.coordinator,
-                selector: #selector(Coordinator.windowDidResize(_:)),
-                name: NSWindow.didResizeNotification,
-                object: window
-            )
+    @State private var dragStartHeight: Double?
+    @State private var isHovering = false
+
+    var body: some View {
+        ZStack {
+            Color.clear
+            Capsule()
+                .fill(Color.secondary.opacity(isHovering ? 0.55 : 0.25))
+                .frame(width: 32, height: 4)
         }
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {}
-
-    func makeCoordinator() -> Coordinator { Coordinator(windowHeight: $windowHeight) }
-
-    class Coordinator: NSObject {
-        @Binding var windowHeight: Double
-        init(windowHeight: Binding<Double>) { _windowHeight = windowHeight }
-
-        @objc func windowDidResize(_ notification: Notification) {
-            guard let window = notification.object as? NSWindow else { return }
-            DispatchQueue.main.async { self.windowHeight = Double(window.frame.height) }
+        .frame(maxWidth: .infinity)
+        .frame(height: 10)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovering = hovering
+            if hovering { NSCursor.resizeUpDown.push() }
+            else { NSCursor.pop() }
         }
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    let start = dragStartHeight ?? height
+                    if dragStartHeight == nil { dragStartHeight = start }
+                    let proposed = start + Double(value.translation.height)
+                    height = max(minHeight, min(maxHeight, proposed))
+                }
+                .onEnded { _ in
+                    dragStartHeight = nil
+                }
+        )
     }
 }


### PR DESCRIPTION
## Problem

The "Resizable window" feature shipped in v2.21.0 (PR #12) doesn't work — the popover never changes size when the user tries to drag.

## Root cause

Three layered problems in `WindowResizer` (`MenuBarView.swift:3974-4011`):

1. **Setup race — never executes.** `makeNSView` returns immediately, then dispatches its setup to the next runloop turn and guards on `view.window`. But SwiftUI hasn't attached the `NSHostingView` to its window by that point, so the guard exits silently every time. `.resizable` is never inserted into the styleMask, the `didResize` observer is never installed, and the user's drag does nothing.
2. **No visible affordance.** Even if (1) had worked, `MenuBarExtra(.window)` is borderless and shows no resize indicator at the edges. The cursor doesn't change. Users have no cue.
3. **Layout fight.** The outer `.frame(height: manager.windowHeight)` would have fought any AppKit-driven resize until the binding caught up.

## Fix

Replaced `WindowResizer` with a pure-SwiftUI `ResizeHandle`:

- 10pt-tall strip with a centered capsule indicator (visible cue)
- `.resizeUpDown` cursor on hover via `NSCursor.push/pop`
- `DragGesture` updates `manager.windowHeight` directly with start-anchor + clamp to `[400, 1400]`
- SwiftUI's existing `.frame(height: manager.windowHeight)` drives the MenuBarExtra panel size, so the popover grows / shrinks as the binding moves — no NSWindow style-mask hackery, no race conditions, works the same on every macOS version

## Test plan

- [ ] Open the popover — small grip indicator visible just above the bottom toolbar
- [ ] Hover over the grip — cursor changes to vertical resize
- [ ] Drag down — popover grows downward, content reflows; drag up — popover shrinks
- [ ] Bounds: try to drag below 400 → clamped; above 1400 → clamped
- [ ] Close + reopen popover — height persists at the new value (UserDefaults binding unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)