### PR TITLE
feat: Apple Watch-style activity rings menubar icon mode

### DIFF
--- a/Sources/ClaudeUsageApp.swift
+++ b/Sources/ClaudeUsageApp.swift
@@ -19,16 +19,26 @@ struct ClaudeGodApp: App {
             MenuBarView(manager: manager)
         } label: {
             HStack(spacing: 4) {
-                Image(systemName: manager.menuBarIcon)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(manager.menuBarIconColor.opacity(manager.menuBarIconOpacity))
+                if manager.menuBarDisplayMode == .iconPlus {
+                    // Apple Watch-style concentric rings
+                    MenuBarRingView(
+                        quotas: manager.quotas,
+                        labels: manager.ringStatLabels
+                    )
+                } else {
+                    Image(systemName: manager.menuBarIcon)
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(manager.menuBarIconColor.opacity(manager.menuBarIconOpacity))
+                }
                 if manager.isSessionActive {
                     Circle()
                         .fill(.green)
                         .frame(width: 5, height: 5)
                 }
-                Text(manager.menuBarTitle)
-                    .monospacedDigit()
+                if !manager.menuBarTitle.isEmpty {
+                    Text(manager.menuBarTitle)
+                        .monospacedDigit()
+                }
             }
         }
         .menuBarExtraStyle(.window)

--- a/Sources/ClaudeUsageApp.swift
+++ b/Sources/ClaudeUsageApp.swift
@@ -19,10 +19,10 @@ struct ClaudeGodApp: App {
             MenuBarView(manager: manager)
         } label: {
             HStack(spacing: 4) {
-                if manager.menuBarDisplayMode == .iconPlus {
+                if manager.menuBarDisplayMode == .rings {
                     // Apple Watch-style concentric rings
                     MenuBarRingView(
-                        quotas: manager.quotas,
+                        quotas: manager.ringQuotaOptions,
                         labels: manager.ringStatLabels
                     )
                 } else {

--- a/Sources/MenuBarRingView.swift
+++ b/Sources/MenuBarRingView.swift
@@ -1,90 +1,32 @@
 // MenuBarRingView.swift
-// Apple Watch Activity-style concentric rings for the Icon+ menubar mode.
-// Uses Canvas (Core Graphics path drawing) so it renders correctly in the
-// MenuBarExtra label — composited SwiftUI Circles distort in that context.
+// Thin SwiftUI wrapper around RingImageMaker — used in the MenuBarExtra label
+// and as a color-palette reference for the settings panel.
 
 import SwiftUI
+import AppKit
 
-// MARK: - Multi-ring menubar icon (Canvas-based)
+// MARK: - Menubar icon (NSImage-backed, full color)
 
 struct MenuBarRingView: View {
 
-    /// Quota objects available for look-up.
     let quotas: [UsageQuota]
-    /// Up to 3 quota labels to display. Empty string = unused slot.
     let labels: [String]
 
-    // ── Apple Watch Activity ring palette ──
-    // outer = Move (red), mid = Exercise (green), inner = Stand (cyan)
+    // SwiftUI Color equivalents for the settings UI legend
     static let ringColors: [Color] = [
-        Color(red: 1.00, green: 0.31, blue: 0.25),
-        Color(red: 0.31, green: 0.90, blue: 0.46),
-        Color(red: 0.05, green: 0.73, blue: 0.93),
+        Color(nsColor: RingImageMaker.ringNSColors[0]),
+        Color(nsColor: RingImageMaker.ringNSColors[1]),
+        Color(nsColor: RingImageMaker.ringNSColors[2]),
     ]
 
-    // ── Layout constants ──
-    private static let canvasSize: CGFloat = 20   // icon bounding box
-    private static let lineWidth:  CGFloat = 2.0
-    private static let step:       CGFloat = 2.5  // radial distance between ring centres
-
-    // Resolved (progress 0-1, color) pairs — only non-empty matched labels
-    private var rings: [(progress: Double, color: Color)] {
-        labels.prefix(3).enumerated().compactMap { i, label in
-            guard !label.isEmpty,
-                  let q = quotas.first(where: { $0.label == label })
-            else { return nil }
-            return (progress: min(q.utilization / 100.0, 1.0),
-                    color: Self.ringColors[i % Self.ringColors.count])
-        }
-    }
-
     var body: some View {
-        if rings.isEmpty {
-            // Fallback: plain circled-C when nothing is configured
-            Image(systemName: "c.circle")
-                .font(.system(size: 14, weight: .regular))
-        } else {
-            Canvas { ctx, size in
-                let cx = size.width  / 2
-                let cy = size.height / 2
-                let center = CGPoint(x: cx, y: cy)
-
-                for (i, ring) in rings.enumerated() {
-                    // Outer ring uses the full radius; each inner ring steps inward
-                    let radius = (size.width / 2)
-                                 - Self.lineWidth / 2
-                                 - CGFloat(i) * Self.step
-                    guard radius > Self.lineWidth / 2 else { continue }
-
-                    // ── Dim track (full circle) ──
-                    var track = Path()
-                    track.addArc(center: center, radius: radius,
-                                 startAngle: .degrees(0),
-                                 endAngle:   .degrees(360),
-                                 clockwise: false)
-                    ctx.stroke(track,
-                               with: .color(ring.color.opacity(0.22)),
-                               lineWidth: Self.lineWidth)
-
-                    // ── Progress arc (12-o'clock → clockwise) ──
-                    guard ring.progress > 0 else { continue }
-                    var arc = Path()
-                    arc.addArc(center: center, radius: radius,
-                               startAngle: .degrees(-90),
-                               endAngle:   .degrees(-90 + 360.0 * ring.progress),
-                               clockwise: false)
-                    ctx.stroke(arc,
-                               with: .color(ring.color),
-                               style: StrokeStyle(lineWidth: Self.lineWidth,
-                                                  lineCap: .round))
-                }
-            }
-            .frame(width: Self.canvasSize, height: Self.canvasSize)
-        }
+        Image(nsImage: RingImageMaker.image(quotas: quotas, labels: labels))
+            .interpolation(.high)
+            .antialiased(true)
     }
 }
 
-// MARK: - Settings preview (larger, labeled)
+// MARK: - Settings panel preview (larger, labeled)
 
 private struct SingleRingArc: View {
     let progress: Double
@@ -95,7 +37,7 @@ private struct SingleRingArc: View {
     var body: some View {
         ZStack {
             Circle()
-                .stroke(color.opacity(0.22), lineWidth: lineWidth)
+                .stroke(color.opacity(0.25), lineWidth: lineWidth)
             Circle()
                 .trim(from: 0, to: CGFloat(min(progress, 1.0)))
                 .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))

--- a/Sources/MenuBarRingView.swift
+++ b/Sources/MenuBarRingView.swift
@@ -1,0 +1,129 @@
+// MenuBarRingView.swift
+// Apple Watch Activity-style concentric rings for the Icon+ menubar mode.
+// Up to 3 quota stats are shown as filled arcs, outer→inner.
+
+import SwiftUI
+
+// MARK: - Single ring arc (track + progress)
+
+private struct RingArc: View {
+    let progress: Double   // 0...1
+    let color: Color
+    let diameter: CGFloat
+    let lineWidth: CGFloat
+
+    var body: some View {
+        ZStack {
+            // Dim track
+            Circle()
+                .stroke(color.opacity(0.18), lineWidth: lineWidth)
+            // Filled arc — starts at 12 o'clock, sweeps clockwise
+            Circle()
+                .trim(from: 0, to: CGFloat(min(max(progress, 0), 1.0)))
+                .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .foregroundColor(color)
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: diameter, height: diameter)
+    }
+}
+
+// MARK: - Multi-ring icon
+
+struct MenuBarRingView: View {
+
+    /// Quota objects available for look-up.
+    let quotas: [UsageQuota]
+    /// Up to 3 quota labels to display. Empty string = unused slot.
+    let labels: [String]
+
+    // ── Apple Watch Activity ring palette ──
+    // outer = Move (red), mid = Exercise (green), inner = Stand (cyan)
+    static let ringColors: [Color] = [
+        Color(red: 1.00, green: 0.31, blue: 0.25),
+        Color(red: 0.31, green: 0.90, blue: 0.46),
+        Color(red: 0.05, green: 0.73, blue: 0.93),
+    ]
+
+    // ── Layout constants ──
+    private static let outerDiameter: CGFloat = 20
+    private static let lineWidth:     CGFloat = 2.0
+    private static let step:          CGFloat = 2.5   // lineWidth + 0.5 gap
+
+    // Resolved (utilization, color) pairs — only for non-empty, matched labels
+    private var rings: [(utilization: Double, color: Color)] {
+        labels.prefix(3).enumerated().compactMap { i, label in
+            guard !label.isEmpty,
+                  let q = quotas.first(where: { $0.label == label })
+            else { return nil }
+            return (utilization: q.utilization,
+                    color: Self.ringColors[i % Self.ringColors.count])
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            if rings.isEmpty {
+                // Fallback: plain circled-C icon when no stats are configured
+                Image(systemName: "c.circle")
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundColor(.primary)
+            } else {
+                ForEach(rings.indices, id: \.self) { i in
+                    let diameter = Self.outerDiameter - CGFloat(i) * Self.step * 2
+                    RingArc(
+                        progress: rings[i].utilization / 100.0,
+                        color:    rings[i].color,
+                        diameter: diameter,
+                        lineWidth: Self.lineWidth
+                    )
+                }
+            }
+        }
+        .frame(width: Self.outerDiameter, height: Self.outerDiameter)
+    }
+}
+
+// MARK: - Settings preview (larger, labeled)
+
+struct RingSettingsPreview: View {
+    let quotas: [UsageQuota]
+    let labels: [String]
+
+    var body: some View {
+        HStack(spacing: 12) {
+            MenuBarRingView(quotas: quotas, labels: labels)
+                .scaleEffect(2.2)
+                .frame(width: 48, height: 48)   // enough space for 2.2× scale
+
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(labels.prefix(3).indices, id: \.self) { i in
+                    let label = labels[i]
+                    let util = quotas.first(where: { $0.label == label })?.utilization
+                    HStack(spacing: 5) {
+                        Circle()
+                            .fill(MenuBarRingView.ringColors[i % MenuBarRingView.ringColors.count])
+                            .frame(width: 7, height: 7)
+                        if label.isEmpty {
+                            Text("—")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text(label)
+                                .font(.system(size: 11, weight: .medium))
+                                .lineLimit(1)
+                            Spacer()
+                            if let u = util {
+                                Text("\(Int(u))%")
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Sources/MenuBarRingView.swift
+++ b/Sources/MenuBarRingView.swift
@@ -1,34 +1,11 @@
 // MenuBarRingView.swift
 // Apple Watch Activity-style concentric rings for the Icon+ menubar mode.
-// Up to 3 quota stats are shown as filled arcs, outer→inner.
+// Uses Canvas (Core Graphics path drawing) so it renders correctly in the
+// MenuBarExtra label — composited SwiftUI Circles distort in that context.
 
 import SwiftUI
 
-// MARK: - Single ring arc (track + progress)
-
-private struct RingArc: View {
-    let progress: Double   // 0...1
-    let color: Color
-    let diameter: CGFloat
-    let lineWidth: CGFloat
-
-    var body: some View {
-        ZStack {
-            // Dim track
-            Circle()
-                .stroke(color.opacity(0.18), lineWidth: lineWidth)
-            // Filled arc — starts at 12 o'clock, sweeps clockwise
-            Circle()
-                .trim(from: 0, to: CGFloat(min(max(progress, 0), 1.0)))
-                .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-                .foregroundColor(color)
-                .rotationEffect(.degrees(-90))
-        }
-        .frame(width: diameter, height: diameter)
-    }
-}
-
-// MARK: - Multi-ring icon
+// MARK: - Multi-ring menubar icon (Canvas-based)
 
 struct MenuBarRingView: View {
 
@@ -46,69 +23,136 @@ struct MenuBarRingView: View {
     ]
 
     // ── Layout constants ──
-    private static let outerDiameter: CGFloat = 20
-    private static let lineWidth:     CGFloat = 2.0
-    private static let step:          CGFloat = 2.5   // lineWidth + 0.5 gap
+    private static let canvasSize: CGFloat = 20   // icon bounding box
+    private static let lineWidth:  CGFloat = 2.0
+    private static let step:       CGFloat = 2.5  // radial distance between ring centres
 
-    // Resolved (utilization, color) pairs — only for non-empty, matched labels
-    private var rings: [(utilization: Double, color: Color)] {
+    // Resolved (progress 0-1, color) pairs — only non-empty matched labels
+    private var rings: [(progress: Double, color: Color)] {
         labels.prefix(3).enumerated().compactMap { i, label in
             guard !label.isEmpty,
                   let q = quotas.first(where: { $0.label == label })
             else { return nil }
-            return (utilization: q.utilization,
+            return (progress: min(q.utilization / 100.0, 1.0),
                     color: Self.ringColors[i % Self.ringColors.count])
         }
     }
 
     var body: some View {
-        ZStack {
-            if rings.isEmpty {
-                // Fallback: plain circled-C icon when no stats are configured
-                Image(systemName: "c.circle")
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundColor(.primary)
-            } else {
-                ForEach(rings.indices, id: \.self) { i in
-                    let diameter = Self.outerDiameter - CGFloat(i) * Self.step * 2
-                    RingArc(
-                        progress: rings[i].utilization / 100.0,
-                        color:    rings[i].color,
-                        diameter: diameter,
-                        lineWidth: Self.lineWidth
-                    )
+        if rings.isEmpty {
+            // Fallback: plain circled-C when nothing is configured
+            Image(systemName: "c.circle")
+                .font(.system(size: 14, weight: .regular))
+        } else {
+            Canvas { ctx, size in
+                let cx = size.width  / 2
+                let cy = size.height / 2
+                let center = CGPoint(x: cx, y: cy)
+
+                for (i, ring) in rings.enumerated() {
+                    // Outer ring uses the full radius; each inner ring steps inward
+                    let radius = (size.width / 2)
+                                 - Self.lineWidth / 2
+                                 - CGFloat(i) * Self.step
+                    guard radius > Self.lineWidth / 2 else { continue }
+
+                    // ── Dim track (full circle) ──
+                    var track = Path()
+                    track.addArc(center: center, radius: radius,
+                                 startAngle: .degrees(0),
+                                 endAngle:   .degrees(360),
+                                 clockwise: false)
+                    ctx.stroke(track,
+                               with: .color(ring.color.opacity(0.22)),
+                               lineWidth: Self.lineWidth)
+
+                    // ── Progress arc (12-o'clock → clockwise) ──
+                    guard ring.progress > 0 else { continue }
+                    var arc = Path()
+                    arc.addArc(center: center, radius: radius,
+                               startAngle: .degrees(-90),
+                               endAngle:   .degrees(-90 + 360.0 * ring.progress),
+                               clockwise: false)
+                    ctx.stroke(arc,
+                               with: .color(ring.color),
+                               style: StrokeStyle(lineWidth: Self.lineWidth,
+                                                  lineCap: .round))
                 }
             }
+            .frame(width: Self.canvasSize, height: Self.canvasSize)
         }
-        .frame(width: Self.outerDiameter, height: Self.outerDiameter)
     }
 }
 
 // MARK: - Settings preview (larger, labeled)
 
+private struct SingleRingArc: View {
+    let progress: Double
+    let color: Color
+    let diameter: CGFloat
+    let lineWidth: CGFloat
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(color.opacity(0.22), lineWidth: lineWidth)
+            Circle()
+                .trim(from: 0, to: CGFloat(min(progress, 1.0)))
+                .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: diameter, height: diameter)
+    }
+}
+
 struct RingSettingsPreview: View {
     let quotas: [UsageQuota]
     let labels: [String]
 
-    var body: some View {
-        HStack(spacing: 12) {
-            MenuBarRingView(quotas: quotas, labels: labels)
-                .scaleEffect(2.2)
-                .frame(width: 48, height: 48)   // enough space for 2.2× scale
+    private static let outerDiameter: CGFloat = 44
+    private static let lineWidth:     CGFloat = 4.5
+    private static let step:          CGFloat = 5.5
 
-            VStack(alignment: .leading, spacing: 3) {
-                ForEach(labels.prefix(3).indices, id: \.self) { i in
-                    let label = labels[i]
-                    let util = quotas.first(where: { $0.label == label })?.utilization
+    private var rings: [(label: String, progress: Double, color: Color)] {
+        labels.prefix(3).enumerated().compactMap { i, label in
+            guard !label.isEmpty else { return nil }
+            let util = quotas.first(where: { $0.label == label })?.utilization ?? 0
+            return (label: label,
+                    progress: min(util / 100.0, 1.0),
+                    color: MenuBarRingView.ringColors[i % MenuBarRingView.ringColors.count])
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            // Ring diagram
+            ZStack {
+                if rings.isEmpty {
+                    Image(systemName: "c.circle")
+                        .font(.system(size: 28))
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(rings.indices, id: \.self) { i in
+                        let diam = Self.outerDiameter - CGFloat(i) * Self.step * 2
+                        SingleRingArc(progress: rings[i].progress,
+                                      color:    rings[i].color,
+                                      diameter: max(diam, 4),
+                                      lineWidth: Self.lineWidth)
+                    }
+                }
+            }
+            .frame(width: Self.outerDiameter, height: Self.outerDiameter)
+
+            // Legend
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(0..<3, id: \.self) { i in
                     HStack(spacing: 5) {
                         Circle()
-                            .fill(MenuBarRingView.ringColors[i % MenuBarRingView.ringColors.count])
+                            .fill(MenuBarRingView.ringColors[i])
                             .frame(width: 7, height: 7)
-                        if label.isEmpty {
-                            Text("—")
-                                .font(.system(size: 11))
-                                .foregroundColor(.secondary)
-                        } else {
+                        if i < labels.count && !labels[i].isEmpty {
+                            let label = labels[i]
+                            let util  = quotas.first(where: { $0.label == label })?.utilization
                             Text(label)
                                 .font(.system(size: 11, weight: .medium))
                                 .lineLimit(1)
@@ -118,6 +162,10 @@ struct RingSettingsPreview: View {
                                     .font(.system(size: 11, design: .monospaced))
                                     .foregroundColor(.secondary)
                             }
+                        } else {
+                            Text("—")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
                         }
                     }
                 }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -392,6 +392,64 @@ struct MenuBarView: View {
                 }
             }
 
+            // Icon+ ring configuration
+            if manager.menuBarDisplayMode == .iconPlus {
+                SHCard {
+                    VStack(alignment: .leading, spacing: 10) {
+                        SHLabel("Icon+ Rings")
+                        Text("Choose up to 3 quotas to display as concentric activity rings.")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+
+                        let quotaOptions: [String] = manager.quotas.map(\.label)
+
+                        ForEach(0..<3, id: \.self) { i in
+                            HStack(spacing: 6) {
+                                Circle()
+                                    .fill(MenuBarRingView.ringColors[i])
+                                    .frame(width: 8, height: 8)
+                                Text("Ring \(i + 1)")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .frame(width: 44, alignment: .leading)
+                                Spacer()
+                                let slotBinding = Binding<String>(
+                                    get: {
+                                        i < manager.ringStatLabels.count
+                                            ? manager.ringStatLabels[i] : ""
+                                    },
+                                    set: { newVal in
+                                        var labels = manager.ringStatLabels
+                                        while labels.count <= i { labels.append("") }
+                                        labels[i] = newVal
+                                        manager.ringStatLabels = labels
+                                    }
+                                )
+                                Picker("", selection: slotBinding) {
+                                    Text("None").tag("")
+                                    if quotaOptions.isEmpty {
+                                        Text("Loading…").disabled(true)
+                                    } else {
+                                        ForEach(quotaOptions, id: \.self) { label in
+                                            Text(label).tag(label)
+                                        }
+                                    }
+                                }
+                                .labelsHidden()
+                                .frame(maxWidth: 160)
+                            }
+                        }
+
+                        Divider()
+
+                        // Live preview
+                        RingSettingsPreview(
+                            quotas: manager.quotas,
+                            labels: manager.ringStatLabels
+                        )
+                    }
+                }
+            }
+
             // Custom alert rules
             SHCard {
                 VStack(alignment: .leading, spacing: 8) {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -393,7 +393,7 @@ struct MenuBarView: View {
             }
 
             // Icon+ ring configuration
-            if manager.menuBarDisplayMode == .iconPlus {
+            if manager.menuBarDisplayMode == .rings {
                 SHCard {
                     VStack(alignment: .leading, spacing: 10) {
                         SHLabel("Icon+ Rings")
@@ -401,7 +401,7 @@ struct MenuBarView: View {
                             .font(.system(size: 11))
                             .foregroundColor(.secondary)
 
-                        let quotaOptions: [String] = manager.quotas.map(\.label)
+                        let quotaOptions: [String] = manager.ringQuotaOptions.map(\.label)
 
                         ForEach(0..<3, id: \.self) { i in
                             HStack(spacing: 6) {
@@ -443,7 +443,7 @@ struct MenuBarView: View {
 
                         // Live preview
                         RingSettingsPreview(
-                            quotas: manager.quotas,
+                            quotas: manager.ringQuotaOptions,
                             labels: manager.ringStatLabels
                         )
                     }

--- a/Sources/RingImageMaker.swift
+++ b/Sources/RingImageMaker.swift
@@ -1,0 +1,82 @@
+// RingImageMaker.swift
+// Draws Apple Watch-style activity rings into an NSImage using NSBezierPath.
+// NSImage + isTemplate=false is the only reliable way to show full color in a
+// MenuBarExtra label — SwiftUI Canvas/Circle are treated as template (alpha-only)
+// by macOS in that rendering context.
+
+import AppKit
+
+enum RingImageMaker {
+
+    // ── Apple Watch Activity palette (NSColor, explicit sRGB) ──
+    static let ringNSColors: [NSColor] = [
+        NSColor(srgbRed: 1.00, green: 0.31, blue: 0.25, alpha: 1), // Move  (red)
+        NSColor(srgbRed: 0.31, green: 0.90, blue: 0.46, alpha: 1), // Exercise (green)
+        NSColor(srgbRed: 0.05, green: 0.73, blue: 0.93, alpha: 1), // Stand (cyan)
+    ]
+
+    private static let size:      CGFloat = 20
+    private static let lineWidth: CGFloat = 2.0
+    private static let step:      CGFloat = 2.5   // radial gap between ring centres
+
+    /// Returns a 20×20-point NSImage with 1–3 concentric activity rings.
+    /// Falls back to the SF Symbol "c.circle" when no stats are resolved.
+    static func image(quotas: [UsageQuota], labels: [String]) -> NSImage {
+        let rings: [(progress: Double, color: NSColor)] = labels.prefix(3)
+            .enumerated()
+            .compactMap { i, label in
+                guard !label.isEmpty,
+                      let q = quotas.first(where: { $0.label == label })
+                else { return nil }
+                return (progress: min(q.utilization / 100.0, 1.0),
+                        color: ringNSColors[i % ringNSColors.count])
+            }
+
+        guard !rings.isEmpty else { return fallbackImage() }
+
+        // NSImage with flipped:false → standard macOS y-up coordinate system.
+        // Angles in NSBezierPath.appendArc: 0°=3-o'clock, 90°=12-o'clock,
+        // counterclockwise positive (standard math). clockwise:true sweeps
+        // from startAngle toward smaller angles (visually clockwise on screen).
+        let image = NSImage(size: NSSize(width: size, height: size),
+                            flipped: false) { _ in
+            let center = NSPoint(x: size / 2, y: size / 2)
+
+            for (i, ring) in rings.enumerated() {
+                let radius = (size / 2) - lineWidth / 2 - CGFloat(i) * step
+                guard radius > lineWidth / 2 else { continue }
+
+                // ── Dim track (full circle) ──
+                let track = NSBezierPath()
+                track.appendArc(withCenter: center, radius: radius,
+                                startAngle: 0, endAngle: 360, clockwise: false)
+                track.lineWidth = lineWidth
+                ring.color.withAlphaComponent(0.28).setStroke()
+                track.stroke()
+
+                // ── Progress arc: 12-o'clock (90°) → clockwise ──
+                guard ring.progress > 0 else { continue }
+                let endAngle = 90.0 - CGFloat(ring.progress) * 360.0
+                let arc = NSBezierPath()
+                arc.appendArc(withCenter: center, radius: radius,
+                              startAngle: 90, endAngle: endAngle,
+                              clockwise: true)
+                arc.lineWidth = lineWidth
+                arc.lineCapStyle = .round
+                ring.color.setStroke()
+                arc.stroke()
+            }
+            return true
+        }
+
+        image.isTemplate = false   // preserve colors — never let macOS recolor this
+        return image
+    }
+
+    private static func fallbackImage() -> NSImage {
+        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+        return NSImage(systemSymbolName: "c.circle",
+                       accessibilityDescription: nil)?
+            .withSymbolConfiguration(config) ?? NSImage()
+    }
+}

--- a/Sources/RingImageMaker.swift
+++ b/Sources/RingImageMaker.swift
@@ -51,6 +51,21 @@ enum RingImageMaker {
             let center = NSPoint(x: size / 2, y: size / 2)
             let outerRadius = size / 2 - lineWidth / 2
 
+            // ── Subtle background disc ──
+            // On light menubars the bright rings (especially green) can wash out;
+            // a faint dark circle behind them restores contrast without being obtrusive.
+            // Check appearance at draw time — image is regenerated from the main
+            // thread on every quota refresh so it stays in sync with mode changes.
+            let isDark = NSApp.effectiveAppearance
+                .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            let bgAlpha: CGFloat = isDark ? 0.0 : 0.13
+            if bgAlpha > 0 {
+                let bgPath = NSBezierPath(ovalIn: NSRect(x: 0, y: 0,
+                                                         width: size, height: size))
+                NSColor.black.withAlphaComponent(bgAlpha).setFill()
+                bgPath.fill()
+            }
+
             // ── Rings ──
             for (i, ring) in rings.enumerated() {
                 let radius = outerRadius - CGFloat(i) * step

--- a/Sources/RingImageMaker.swift
+++ b/Sources/RingImageMaker.swift
@@ -8,19 +8,26 @@ import AppKit
 
 enum RingImageMaker {
 
-    // ── Apple Watch Activity palette (NSColor, explicit sRGB) ──
+    // ── Apple Watch Activity palette (explicit sRGB) ──
     static let ringNSColors: [NSColor] = [
         NSColor(srgbRed: 1.00, green: 0.31, blue: 0.25, alpha: 1), // Move  (red)
         NSColor(srgbRed: 0.31, green: 0.90, blue: 0.46, alpha: 1), // Exercise (green)
         NSColor(srgbRed: 0.05, green: 0.73, blue: 0.93, alpha: 1), // Stand (cyan)
     ]
 
+    // ── Layout ──
+    // Rings are thinner than the original to carve out a center well for the "C".
+    // With size=20, lineWidth=1.5, step=2.5:
+    //   ring 0: radius 9.25  (outer)
+    //   ring 1: radius 6.75  (mid)
+    //   ring 2: radius 4.25  (inner)  → clear centre ≈ Ø7 pt → fits a 6-pt "C"
     private static let size:      CGFloat = 20
-    private static let lineWidth: CGFloat = 2.0
-    private static let step:      CGFloat = 2.5   // radial gap between ring centres
+    private static let lineWidth: CGFloat = 1.5
+    private static let step:      CGFloat = 2.5
 
-    /// Returns a 20×20-point NSImage with 1–3 concentric activity rings.
-    /// Falls back to the SF Symbol "c.circle" when no stats are resolved.
+    /// Returns a 20×20-point NSImage with 1–3 concentric activity rings and
+    /// a small "C" centred inside them. Falls back to the "c.circle" SF Symbol
+    /// when no stats are resolved.
     static func image(quotas: [UsageQuota], labels: [String]) -> NSImage {
         let rings: [(progress: Double, color: NSColor)] = labels.prefix(3)
             .enumerated()
@@ -35,18 +42,21 @@ enum RingImageMaker {
         guard !rings.isEmpty else { return fallbackImage() }
 
         // NSImage with flipped:false → standard macOS y-up coordinate system.
-        // Angles in NSBezierPath.appendArc: 0°=3-o'clock, 90°=12-o'clock,
-        // counterclockwise positive (standard math). clockwise:true sweeps
-        // from startAngle toward smaller angles (visually clockwise on screen).
+        // NSBezierPath.appendArc angles: 0°=3-o'clock, 90°=12-o'clock,
+        // positive angles = counter-clockwise (standard math).
+        // clockwise:true sweeps from startAngle toward decreasing angles
+        // = visually clockwise on screen.
         let image = NSImage(size: NSSize(width: size, height: size),
                             flipped: false) { _ in
             let center = NSPoint(x: size / 2, y: size / 2)
+            let outerRadius = size / 2 - lineWidth / 2
 
+            // ── Rings ──
             for (i, ring) in rings.enumerated() {
-                let radius = (size / 2) - lineWidth / 2 - CGFloat(i) * step
+                let radius = outerRadius - CGFloat(i) * step
                 guard radius > lineWidth / 2 else { continue }
 
-                // ── Dim track (full circle) ──
+                // Dim track (full circle)
                 let track = NSBezierPath()
                 track.appendArc(withCenter: center, radius: radius,
                                 startAngle: 0, endAngle: 360, clockwise: false)
@@ -54,7 +64,7 @@ enum RingImageMaker {
                 ring.color.withAlphaComponent(0.28).setStroke()
                 track.stroke()
 
-                // ── Progress arc: 12-o'clock (90°) → clockwise ──
+                // Progress arc — 12-o'clock (90°) → clockwise
                 guard ring.progress > 0 else { continue }
                 let endAngle = 90.0 - CGFloat(ring.progress) * 360.0
                 let arc = NSBezierPath()
@@ -66,10 +76,28 @@ enum RingImageMaker {
                 ring.color.setStroke()
                 arc.stroke()
             }
+
+            // ── "C" in the centre ──
+            // labelColor resolves to black on light menubar, white on dark.
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 6.0, weight: .bold),
+                .foregroundColor: NSColor.labelColor,
+            ]
+            let str = "C" as NSString
+            let strSize = str.size(withAttributes: attrs)
+            // In y-up coords, rect.origin.y is the bottom of the text bounding box
+            let strRect = NSRect(
+                x: center.x - strSize.width  / 2,
+                y: center.y - strSize.height / 2,
+                width:  strSize.width,
+                height: strSize.height
+            )
+            str.draw(in: strRect, withAttributes: attrs)
+
             return true
         }
 
-        image.isTemplate = false   // preserve colors — never let macOS recolor this
+        image.isTemplate = false   // preserve colors — never template-render this
         return image
     }
 

--- a/Sources/SessionAnalyzer.swift
+++ b/Sources/SessionAnalyzer.swift
@@ -26,6 +26,7 @@ enum UDKey {
     static let widgetTodayMessages = "widgetTodayMessages"
     static let widgetLastUpdate = "widgetLastUpdate"
     static let windowHeight = "windowHeight"
+    static let ringStatLabels = "ringStatLabels"
 }
 
 // MARK: - Logging

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -34,7 +34,7 @@ enum RefreshInterval: Int, CaseIterable, Identifiable {
 
 enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     case iconOnly = 0
-    case rings = 4             // Apple Watch-style concentric rings
+    case rings = 5             // Apple Watch-style concentric rings
     case percentage = 1
     case percentageAndTimer = 2
     case allQuotas = 3

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -34,7 +34,7 @@ enum RefreshInterval: Int, CaseIterable, Identifiable {
 
 enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     case iconOnly = 0
-    case iconPlus = 4          // Apple Watch-style concentric rings
+    case rings = 4             // Apple Watch-style concentric rings
     case percentage = 1
     case percentageAndTimer = 2
     case allQuotas = 3
@@ -44,7 +44,7 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .iconOnly: return "Icon"
-        case .iconPlus: return "Icon+"
+        case .rings: return "Rings"
         case .percentage: return "Session"
         case .percentageAndTimer: return "Timer"
         case .allQuotas: return "All"
@@ -54,7 +54,7 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     var description: String {
         switch self {
         case .iconOnly: return "C"
-        case .iconPlus: return "◎ activity rings"
+        case .rings: return "◎ activity rings"
         case .percentage: return "C 15%"
         case .percentageAndTimer: return "C 15% · 2h31m"
         case .allQuotas: return "C 15% | 31% | 22%"
@@ -392,7 +392,27 @@ class UsageManager: ObservableObject {
         }
     }
 
-    /// Up to 3 quota labels displayed as concentric rings in Icon+ mode.
+    // MARK: - Ring stat options (quotas + virtual timer)
+
+    /// Virtual quota: fraction of the 5-hour session window elapsed.
+    /// Ring fills as the window progresses toward reset.
+    var sessionTimerQuota: UsageQuota? {
+        guard let resetDate = nextResetDate else { return nil }
+        let window: TimeInterval = 5 * 3600
+        let remaining = max(0, resetDate.timeIntervalSinceNow)
+        let elapsed = max(0, window - remaining)
+        let pct = min(elapsed / window * 100, 100)
+        return UsageQuota(label: "Timer", icon: "timer", utilization: pct, resetsAt: resetDate)
+    }
+
+    /// All selectable ring options: timer (if available) + live API quotas.
+    var ringQuotaOptions: [UsageQuota] {
+        var opts = quotas
+        if let t = sessionTimerQuota { opts.insert(t, at: 0) }
+        return opts
+    }
+
+    /// Up to 3 quota labels displayed as concentric rings in Rings mode.
     /// Empty string = ring slot unused.
     @Published var ringStatLabels: [String] {
         didSet {
@@ -415,7 +435,7 @@ class UsageManager: ObservableObject {
 
     var menuBarTitle: String {
         switch menuBarDisplayMode {
-        case .iconOnly, .iconPlus:
+        case .iconOnly, .rings:
             return ""
         case .percentage:
             guard let q = primaryQuota else { return "—" }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -34,6 +34,7 @@ enum RefreshInterval: Int, CaseIterable, Identifiable {
 
 enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     case iconOnly = 0
+    case iconPlus = 4          // Apple Watch-style concentric rings
     case percentage = 1
     case percentageAndTimer = 2
     case allQuotas = 3
@@ -43,6 +44,7 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .iconOnly: return "Icon"
+        case .iconPlus: return "Icon+"
         case .percentage: return "Session"
         case .percentageAndTimer: return "Timer"
         case .allQuotas: return "All"
@@ -52,6 +54,7 @@ enum MenuBarDisplayMode: Int, CaseIterable, Identifiable {
     var description: String {
         switch self {
         case .iconOnly: return "C"
+        case .iconPlus: return "◎ activity rings"
         case .percentage: return "C 15%"
         case .percentageAndTimer: return "C 15% · 2h31m"
         case .allQuotas: return "C 15% | 31% | 22%"
@@ -389,6 +392,16 @@ class UsageManager: ObservableObject {
         }
     }
 
+    /// Up to 3 quota labels displayed as concentric rings in Icon+ mode.
+    /// Empty string = ring slot unused.
+    @Published var ringStatLabels: [String] {
+        didSet {
+            if let data = try? JSONEncoder().encode(ringStatLabels) {
+                UserDefaults.standard.set(data, forKey: UDKey.ringStatLabels)
+            }
+        }
+    }
+
     // MARK: - Propriétés calculées
 
     var primaryQuota: UsageQuota? {
@@ -402,7 +415,7 @@ class UsageManager: ObservableObject {
 
     var menuBarTitle: String {
         switch menuBarDisplayMode {
-        case .iconOnly:
+        case .iconOnly, .iconPlus:
             return ""
         case .percentage:
             guard let q = primaryQuota else { return "—" }
@@ -675,6 +688,14 @@ class UsageManager: ObservableObject {
         let savedDisplayMode = ud.integer(forKey: UDKey.menuBarDisplayMode)
         self.menuBarDisplayMode = MenuBarDisplayMode(rawValue: savedDisplayMode) ?? .percentageAndTimer
         self.dailyBudget = ud.double(forKey: UDKey.dailyBudget)
+
+        // Load ring stat labels for Icon+ mode
+        if let data = ud.data(forKey: UDKey.ringStatLabels),
+           let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            self.ringStatLabels = decoded
+        } else {
+            self.ringStatLabels = ["Session (5h)", "Opus (7d)", "Sonnet (7d)"]
+        }
 
         // Load per-project budgets
         if let data = ud.data(forKey: UDKey.projectBudgets),


### PR DESCRIPTION
## Summary

- Adds a new **Rings** menubar icon mode displaying Apple Watch–style activity rings, one per configured usage quota 
  - dark background <img width="33" height="28" alt="Screenshot 2026-05-04 at 07 54 14" src="https://github.com/user-attachments/assets/1f348b20-9f4d-44b4-bc50-b5ca2d0dd54d" /> 
  - light background <img width="30" height="27" alt="Screenshot 2026-05-04 at 07 56 45" src="https://github.com/user-attachments/assets/4e40accc-c9bb-48f5-8617-492658ee5545" />
- New `RingImageMaker` draws rings via `NSBezierPath` into an `NSImage` for correct appearance-aware rendering in the menubar
- New `MenuBarRingView` wraps the image for use in the `MenuBarExtra` label and exposes ring colors for the settings legend
- Settings panel includes a `RingSettingsPreview` with a live labeled legend and a timer ring option

## Test plan


- [ ] Build and run; switch menubar icon mode to "Rings" in settings
- [ ] Verify rings render correctly in both light and dark menu bar appearance
- [ ] Configure 1, 2, and 3 quota labels and confirm ring count updates accordingly
- [ ] Enable the timer ring option and confirm it appears as the innermost ring
- [ ] Verify the settings preview legend matches the menubar icon colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)