### PR TITLE
fix: resolve issue #21 — session expired cannot recover

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -169,18 +169,14 @@ class AuthManager: ObservableObject {
         Log.info("selfRefreshToken: attempting refresh_token grant")
         var request = URLRequest(url: Self.oauthTokenURL)
         request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.setValue("claude-code/2.1", forHTTPHeaderField: "User-Agent")
-        let body: [String: String] = [
-            "grant_type": "refresh_token",
-            "refresh_token": rt,
-            "client_id": Self.oauthClientID
-        ]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
-            completion(false)
-            return
-        }
-        request.httpBody = bodyData
+        // RFC 6749 §6 requires form-encoded bodies for token endpoint requests.
+        var allowedChars = CharacterSet.alphanumerics
+        allowedChars.insert(charactersIn: "-._~")
+        let encodedToken = rt.addingPercentEncoding(withAllowedCharacters: allowedChars) ?? rt
+        let bodyString = "grant_type=refresh_token&refresh_token=\(encodedToken)&client_id=\(Self.oauthClientID)"
+        request.httpBody = bodyString.data(using: .utf8)
 
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             guard let self else { return }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -703,6 +703,7 @@ class UsageManager: ObservableObject {
     private var activeSessionTimer: AnyCancellable?
     private var reconnectPollTimer: AnyCancellable?
     private var tokenHealthTimer: AnyCancellable?
+    private var expiredCredentialTimer: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
     private var isRefreshingToken = false
     private var tokenRefreshQueue: [(Bool) -> Void] = [] // queued callbacks for concurrent refresh requests
@@ -822,6 +823,9 @@ class UsageManager: ObservableObject {
                     if self.autoReconnect && !self.isAutoReconnecting && !self.reconnectExhausted {
                         self.launchAutoReconnect()
                     }
+                    // Poll credentials in the background so a manual `claude auth login`
+                    // in any terminal is picked up without the user clicking Sign In.
+                    self.startExpiredCredentialPolling()
                     return
                 }
                 if self.isAuthenticated && !self.isLoading && (self.quotas.isEmpty || self.errorMessage != nil) {
@@ -1140,12 +1144,20 @@ class UsageManager: ObservableObject {
             "/opt/homebrew/bin/claude",
             "\(home)/.npm-global/bin/claude",
             "\(home)/.local/bin/claude",
+            "\(home)/.local/share/fnm/aliases/default/bin/claude",
             "/usr/bin/claude"
         ]
-        guard let claudePath = candidatePaths.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
+        var claudePath = candidatePaths.first(where: { FileManager.default.fileExists(atPath: $0) })
+
+        if claudePath == nil {
+            // Fallback: ask the user's login shell where claude lives
+            claudePath = Self.resolveClaudeBinaryViaShell()
+        }
+
+        guard let claudePath else {
             Log.warn("claude binary not found — cannot auto-reconnect")
             isAutoReconnecting = false
-            errorMessage = "Session expired — run `claude auth login` in Terminal"
+            errorMessage = "Claude CLI not found. Install it with `npm i -g @anthropic-ai/claude-code`, then run `claude auth login` in Terminal."
             return
         }
 
@@ -1160,6 +1172,53 @@ class UsageManager: ObservableObject {
         terminalSession?.stop()
         terminalSession = nil
         isAutoReconnecting = false
+    }
+
+    /// Resolve the `claude` binary by running `which claude` in the user's login shell.
+    /// Covers nvm, fnm, volta, pnpm global, and other non-standard install locations.
+    private static func resolveClaudeBinaryViaShell() -> String? {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: shell)
+        p.arguments = ["-l", "-c", "which claude"]
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        p.standardError = Pipe()
+        do {
+            try p.run()
+            p.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard p.terminationStatus == 0 else { return nil }
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+        let path = String(data: raw, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return path.isEmpty ? nil : path
+    }
+
+    /// Poll credentials every 10 seconds when the token is expired but no reconnect flow is running.
+    /// This picks up tokens written by a manual `claude auth login` in any terminal.
+    private func startExpiredCredentialPolling() {
+        expiredCredentialTimer?.cancel()
+        expiredCredentialTimer = Timer.publish(every: 10, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                guard self.auth.tokenExpired, !self.isAutoReconnecting else {
+                    self.expiredCredentialTimer?.cancel()
+                    self.expiredCredentialTimer = nil
+                    return
+                }
+                self.auth.reloadCredentials { [weak self] _ in
+                    guard let self, !self.auth.tokenExpired else { return }
+                    Log.info("Expired credential poller: fresh credentials detected, resuming")
+                    self.expiredCredentialTimer?.cancel()
+                    self.expiredCredentialTimer = nil
+                    self.reconnectExhausted = false
+                    self.errorMessage = nil
+                    self.refresh()
+                }
+            }
     }
 
     private func startReconnectPolling() {
@@ -1492,6 +1551,9 @@ class UsageManager: ObservableObject {
         isLoading = false
         loadingStartedAt = nil
         errorMessage = error
+        if let error, (error.contains("expired") || error.contains("login") || error.contains("authenticated")) {
+            startExpiredCredentialPolling()
+        }
     }
 
     // MARK: - Response parsing (Codable)


### PR DESCRIPTION
Fixes #21 — three root causes diagnosed with help from network traces provided by the reporter.

## Root causes & fixes

### 1. Claude binary not found (nvm/fnm/volta/pnpm installs)
`launchAutoReconnect()` checked only 5 hardcoded paths; if `claude` was installed via a version manager it was never found, making the Sign In button appear to do nothing.

**Fix:** Added `resolveClaudeBinaryViaShell()` — runs `$SHELL -l -c "which claude"` so the user's login-shell PATH (nvm, fnm, volta, pnpm global, etc.) is searched. Also adds the fnm default-alias path as a hardcoded candidate and improves the "not found" error message.

### 2. No credential polling after manual `claude auth login`
On macOS, Claude Code often writes credentials to Keychain only (not `~/.claude/.credentials.json`). The existing file watcher never picked these up.

**Fix:** Added `startExpiredCredentialPolling()` — when the token is expired and no reconnect flow is active, polls `reloadCredentials` (file + Keychain) every 10 seconds. Cancels itself as soon as fresh credentials are detected.

### 3. OAuth token refresh returning HTTP 400
Network traces from the reporter showed TLS/QUIC succeeding but all three token-refresh attempts getting HTTP 400 (Bad Request). The request body and size were identical across all attempts, pointing to a request-format problem rather than an expired token.

**Fix:** `selfRefreshToken` was sending `Content-Type: application/json`. RFC 6749 §6 requires `application/x-www-form-urlencoded` for token endpoint requests. Switched to form encoding with proper percent-encoding of the refresh token.

## Test plan
- [ ] Install `claude` via nvm/fnm/volta, trigger session expiry → Sign In should succeed
- [ ] Run `claude auth login` in a separate terminal while Claude God shows "Session expired" → should auto-recover within 10 seconds
- [ ] Verify token refresh no longer returns HTTP 400 (Console.app: `selfRefreshToken: success` log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)