### PR TITLE
Update peak hours code and references to corrent values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- **Peak hours window updated to Anthropic's new 5am–11am PT band** — reflects the policy change announced 2026-03-26 where 5-hour session limits burn faster during weekdays 5am–11am Pacific (1pm–7pm GMT) due to overlapping US-morning, European-afternoon, and Asia-evening demand. Tooltips and transition countdowns now derive from a single `peakHoursDescription` source-of-truth on `UsageManager` ([#24](https://github.com/Lcharvol/Claude-God/pull/24))
+
 ## [2.22.1] - 2026-05-26
 
 ### Fixed

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -698,7 +698,7 @@ struct MenuBarView: View {
                             .fill((manager.isPeakHours ? Color.orange : Color.indigo).opacity(0.05))
                     )
             )
-            .help("Peak hours: Mon–Fri 7am–5pm PT (US Pacific)")
+            .help("Peak hours: Mon–Fri 5am–11am PT (US Pacific)")
 
             // Live session cost
             if manager.isSessionActive && manager.activeSessionCost > 0 {
@@ -937,7 +937,7 @@ struct MenuBarView: View {
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.secondary)
             }
-            .help("Peak hours: Mon–Fri 7am–5pm PT")
+            .help("Peak hours: Mon–Fri 5am–11am PT")
 
             if let lastRefresh = manager.lastRefresh {
                 HStack {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -698,7 +698,7 @@ struct MenuBarView: View {
                             .fill((manager.isPeakHours ? Color.orange : Color.indigo).opacity(0.05))
                     )
             )
-            .help("Peak hours: Mon–Fri 5am–11am PT (US Pacific)")
+            .help("Peak hours: \(UsageManager.peakHoursDescription) (US Pacific)")
 
             // Live session cost
             if manager.isSessionActive && manager.activeSessionCost > 0 {
@@ -937,7 +937,7 @@ struct MenuBarView: View {
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.secondary)
             }
-            .help("Peak hours: Mon–Fri 5am–11am PT")
+            .help("Peak hours: \(UsageManager.peakHoursDescription)")
 
             if let lastRefresh = manager.lastRefresh {
                 HStack {

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -516,10 +516,10 @@ class UsageManager: ObservableObject {
 
     // MARK: - Peak / Off-peak detection
 
-    /// Peak hours: weekdays 7am–5pm US Pacific (when most US users are active)
+    /// Peak hours: weekdays 5am–11am US Pacific (when most US users are active)
     private static let peakTimezone = TimeZone(identifier: "America/Los_Angeles")!
-    private static let peakStartHour = 7
-    private static let peakEndHour = 17
+    private static let peakStartHour = 5
+    private static let peakEndHour = 11
 
     var isPeakHours: Bool {
         let cal = Calendar.current
@@ -540,7 +540,7 @@ class UsageManager: ObservableObject {
         let now = Date()
 
         if isPeakHours {
-            // Currently peak → find when off-peak starts (5pm PT today)
+            // Currently peak → find when off-peak starts (11am PT today)
             var comps = pacificCal.dateComponents([.year, .month, .day], from: now)
             comps.hour = Self.peakEndHour
             comps.minute = 0
@@ -569,7 +569,7 @@ class UsageManager: ObservableObject {
                 } else if currentWeekday == 1 { // Sunday
                     daysUntilPeak = 1
                 } else {
-                    // Weekday after 5pm → next weekday morning
+                    // Weekday after 11am → next weekday morning
                     daysUntilPeak = currentWeekday == 6 ? 3 : 1 // Friday → Monday, else tomorrow
                 }
             }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -516,10 +516,24 @@ class UsageManager: ObservableObject {
 
     // MARK: - Peak / Off-peak detection
 
-    /// Peak hours: weekdays 5am–11am US Pacific (when most US users are active)
+    /// Peak hours: weekdays 5am–11am US Pacific. Anthropic's throttling window for 5-hour
+    /// session limits — overlap of US morning, European afternoon, and Asia evening demand
+    /// (announced 2026-03-26: https://x.com/trq212/status/2037254607001559305).
     private static let peakTimezone = TimeZone(identifier: "America/Los_Angeles")!
     private static let peakStartHour = 5
     private static let peakEndHour = 11
+
+    /// Human-readable peak window, derived from `peakStartHour` / `peakEndHour` so tooltips
+    /// stay in sync if the policy changes.
+    static var peakHoursDescription: String {
+        "Mon–Fri \(formatHour(peakStartHour))–\(formatHour(peakEndHour)) PT"
+    }
+
+    private static func formatHour(_ hour: Int) -> String {
+        let suffix = hour < 12 ? "am" : "pm"
+        let display = hour == 0 ? 12 : (hour <= 12 ? hour : hour - 12)
+        return "\(display)\(suffix)"
+    }
 
     var isPeakHours: Bool {
         let cal = Calendar.current


### PR DESCRIPTION
## What

Peak and Off-Peak hours are stale. Recent communication indicates that its now 5am-11am Pacific

https://ol.reddit.com/r/ClaudeAI/comments/1s4idaq/update_on_session_limits/
<img width="821" height="383" alt="image" src="https://github.com/user-attachments/assets/5182f831-6810-4540-97b9-19d37b0d8c99" />


## Why

So that peak in the widget represents reality and users don't accidentally get nailed on usage

## Testing

I didn't test it yet, was looking for feedback on whether or not this quick change was welcome before doing more. 
