### PR TITLE
fix: resolve post-login crash and improve credential detection (issue #26)

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 import Combine
+import Security
 
 // MARK: - Credential source
 
@@ -306,10 +307,22 @@ class AuthManager: ObservableObject {
 
     // MARK: - Keychain
 
-    private static func loadFromKeychain() -> [String: Any]? {
+    /// Load credentials from Keychain.
+    /// Fast path: exact "Claude Code-credentials" service. If missing or expired,
+    /// falls back to scanning all entries with that prefix (covers per-project
+    /// suffixed entries written by newer Claude Code versions).
+    static func loadFromKeychain() -> [String: Any]? {
+        if let result = loadKeychainEntry(service: "Claude Code-credentials") {
+            let expiresAt = (result["claudeAiOauth"] as? [String: Any])?["expiresAt"] as? Double ?? 0
+            if Date(timeIntervalSince1970: expiresAt / 1000) > Date() { return result }
+        }
+        return loadBestKeychainEntryWithPrefix("Claude Code-credentials")
+    }
+
+    private static func loadKeychainEntry(service: String) -> [String: Any]? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["find-generic-password", "-s", "Claude Code-credentials", "-w"]
+        process.arguments = ["find-generic-password", "-s", service, "-w"]
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -321,7 +334,6 @@ class AuthManager: ObservableObject {
             guard process.terminationStatus == 0 else { return nil }
 
             let rawData = pipe.fileHandleForReading.readDataToEndOfFile()
-            // Trim whitespace from raw output before parsing
             guard let trimmed = String(data: rawData, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                   !trimmed.isEmpty,
@@ -333,5 +345,45 @@ class AuthManager: ObservableObject {
         } catch {
             return nil
         }
+    }
+
+    private static func loadBestKeychainEntryWithPrefix(_ prefix: String) -> [String: Any]? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var raw: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &raw) == errSecSuccess,
+              let items = raw as? [[String: Any]] else { return nil }
+
+        var bestJSON: [String: Any]?
+        var bestExpiry: Double = 0
+
+        for item in items {
+            guard let service = item[kSecAttrService as String] as? String,
+                  service.hasPrefix(prefix),
+                  let data = item[kSecValueData as String] as? Data,
+                  let trimmed = String(data: data, encoding: .utf8)?
+                      .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty,
+                  let jsonData = trimmed.data(using: .utf8),
+                  let json = (try? JSONSerialization.jsonObject(with: jsonData)) as? [String: Any],
+                  let oauth = json["claudeAiOauth"] as? [String: Any],
+                  let token = oauth["accessToken"] as? String, !token.isEmpty
+            else { continue }
+
+            let expiresAt = oauth["expiresAt"] as? Double ?? 0
+            if expiresAt > bestExpiry {
+                bestExpiry = expiresAt
+                bestJSON = json
+            }
+        }
+
+        if bestJSON != nil {
+            Log.info("loadBestKeychainEntryWithPrefix: using suffixed entry (prefix: \(prefix))")
+        }
+        return bestJSON
     }
 }

--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -312,18 +312,9 @@ class AuthManager: ObservableObject {
     /// falls back to scanning all entries with that prefix (covers per-project
     /// suffixed entries written by newer Claude Code versions).
     static func loadFromKeychain() -> [String: Any]? {
-        if let result = loadKeychainEntry(service: "Claude Code-credentials") {
-            let expiresAt = (result["claudeAiOauth"] as? [String: Any])?["expiresAt"] as? Double ?? 0
-            if Date(timeIntervalSince1970: expiresAt / 1000) > Date() { return result }
-        }
-        return loadBestKeychainEntryWithPrefix("Claude Code-credentials")
-    }
-
-    private static func loadKeychainEntry(service: String) -> [String: Any]? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["find-generic-password", "-s", service, "-w"]
-
+        process.arguments = ["find-generic-password", "-s", "Claude Code-credentials", "-w"]
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = Pipe()
@@ -331,20 +322,18 @@ class AuthManager: ObservableObject {
         do {
             try process.run()
             process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
+            if process.terminationStatus == 0,
+               let trimmed = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                   .trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty,
+               let jsonData = trimmed.data(using: .utf8),
+               let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
+                let expiresAt = (json["claudeAiOauth"] as? [String: Any])?["expiresAt"] as? Double ?? 0
+                if Date(timeIntervalSince1970: expiresAt / 1000) > Date() { return json }
+            }
+        } catch {}
 
-            let rawData = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let trimmed = String(data: rawData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !trimmed.isEmpty,
-                  let jsonData = trimmed.data(using: .utf8),
-                  let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
-            else { return nil }
-
-            return json
-        } catch {
-            return nil
-        }
+        return loadBestKeychainEntryWithPrefix("Claude Code-credentials")
     }
 
     private static func loadBestKeychainEntryWithPrefix(_ prefix: String) -> [String: Any]? {

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -94,6 +94,7 @@ struct MenuBarView: View {
         }
         .frame(width: manager.compactMode && !manager.showSettings && manager.selectedTab == .usage ? 300 : 400,
                height: manager.windowHeight)
+        .background(WindowTopAnchor(height: manager.windowHeight))
         .animation(.easeOut(duration: 0.15), value: manager.selectedTab)
         .animation(.easeOut(duration: 0.15), value: manager.showSettings)
         .onAppear {
@@ -4093,5 +4094,33 @@ struct ResizeHandle: View {
                     dragStartHeight = nil
                 }
         )
+    }
+}
+
+// MARK: - Window top-edge anchor
+
+/// Pins the top edge of the MenuBarExtra window to the status-bar item when height
+/// changes. Without this, SwiftUI resizes from the window's center point in Release
+/// builds, causing the popover to grow/shrink from both the top and bottom.
+struct WindowTopAnchor: NSViewRepresentable {
+    let height: Double
+
+    func makeNSView(context: Context) -> NSView { NSView() }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Defer so the SwiftUI layout pass has already applied the new frame size.
+        DispatchQueue.main.async {
+            guard let window = nsView.window else { return }
+            let current = window.frame
+            guard abs(current.height - height) > 0.5 else { return }
+            // Keep the top edge (maxY) fixed; adjust origin.y downward as height grows.
+            let newOriginY = current.maxY - height
+            window.setFrame(
+                NSRect(x: current.origin.x, y: newOriginY,
+                       width: current.width, height: height),
+                display: false,
+                animate: false
+            )
+        }
     }
 }

--- a/Sources/TerminalSession.swift
+++ b/Sources/TerminalSession.swift
@@ -53,7 +53,7 @@ final class TerminalSession: ObservableObject {
         p.arguments = args
 
         // Give the process the slave end as its terminal
-        let slaveHandle = FileHandle(fileDescriptor: slave, closeOnDealloc: true)
+        let slaveHandle = FileHandle(fileDescriptor: slave, closeOnDealloc: false)
         p.standardInput  = slaveHandle
         p.standardOutput = slaveHandle
         p.standardError  = slaveHandle


### PR DESCRIPTION
## Summary

Fixes #26 — users stuck in "signing in" after a successful `claude auth login`.

Investigation revealed **two separate problems** affecting the auth login flow:

### 1. Post-login crash (`TerminalSession.swift`)

The embedded `claude auth login` terminal session was reliably crashing the app immediately after completing, which prevented credentials from ever being picked up.

**Root cause:** `FileHandle(fileDescriptor: slave, closeOnDealloc: true)` was used for the PTY slave end, then `close(slave)` was also called explicitly. After the first `close()` recycled the FD number, the OS reused it for a guarded socket/keychain FD. When the `Process` object later released the file handle on a background thread, `NSConcreteFileHandle.dealloc` called `close()` on that now-guarded FD → `EXC_GUARD` crash.

**Fix:** `closeOnDealloc: false` — since the PTY slave FD is already closed explicitly after fork, the handle's dealloc must not attempt a second close.

### 2. Credentials not detected after login (`AuthManager.swift`)

Newer Claude Code versions write credentials to **per-project suffixed keychain entries** (e.g. `"Claude Code-credentials/path/to/project"`) and may not update the base `"Claude Code-credentials"` entry. Claude God only read the base entry, so if it was absent or expired, credentials went undetected.

**Fix:** Two-step `loadFromKeychain()`: fast path reads the base entry (unchanged behaviour if valid); if missing or expired, a Security framework scan finds the best entry among all keychain items whose service name starts with `"Claude Code-credentials"`.

### 3. Window resize anchoring (`MenuBarView.swift`)

In Homebrew/Release builds, changing the window height resized from the window's center point, causing the popover to grow/shrink from both top and bottom. `WindowTopAnchor` defers a `window.setFrame()` call that keeps `maxY` (the top edge, anchored to the status bar item) fixed.

## Test plan

- [ ] Press "Sign In" in the app — confirm no crash occurs after completing `claude auth login`
- [ ] After login completes, confirm the usage tab loads successfully
- [ ] On a system where the base `"Claude Code-credentials"` entry is absent/expired but suffixed entries exist, confirm credentials are still detected
- [ ] Resize the window via the drag handle (brew build) — confirm it only grows downward

🤖 Generated with [Claude Code](https://claude.com/claude-code)