### PR TITLE
feat: multi-profile quota tracking (issue #14)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/mcp.json",
+  "mcpServers": {
+    "xcode": {
+      "command": "xcrun",
+      "args": ["mcpbridge"]
+    }
+  }
+}

--- a/Sources/AccountSource.swift
+++ b/Sources/AccountSource.swift
@@ -1,0 +1,42 @@
+// AccountSource.swift
+// Describes where a profile's OAuth credentials live.
+// Based on Claude God (MIT © 2025 Lucas Charvolin).
+
+import Foundation
+
+/// Where a profile's OAuth credentials are stored.
+/// Keychain is the primary case (how Claude Code stores creds on modern installs).
+/// File is the fallback for profiles whose Keychain entry cannot be correlated.
+enum AccountSource: Codable, Equatable, Hashable {
+    /// A macOS Keychain generic-password service name.
+    /// Discovered at first launch via token-correlation against the profile directory.
+    /// Example: "Claude Code-credentials-personal"
+    case keychainService(String)
+
+    /// An absolute path to a credentials file.
+    /// Example: "~/.claude-work/.credentials.json"
+    case credentialsFile(String)
+
+    private enum Kind: String, Codable { case keychain, file }
+    private enum CodingKeys: String, CodingKey { case kind, value }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(Kind.self, forKey: .kind) {
+        case .keychain: self = .keychainService(try c.decode(String.self, forKey: .value))
+        case .file:     self = .credentialsFile(try c.decode(String.self, forKey: .value))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .keychainService(let s):
+            try c.encode(Kind.keychain, forKey: .kind)
+            try c.encode(s, forKey: .value)
+        case .credentialsFile(let p):
+            try c.encode(Kind.file, forKey: .kind)
+            try c.encode(p, forKey: .value)
+        }
+    }
+}

--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -1,5 +1,6 @@
 // AuthManager.swift
 // Handles OAuth authentication, credential loading, token refresh, and token persistence
+// Based on Claude God (MIT © 2025 Lucas Charvolin).
 
 import Foundation
 import Combine
@@ -86,6 +87,57 @@ class AuthManager: ObservableObject {
                 self.credentialSource = .none
                 self.isAuthenticated = false
                 Log.warn("No credentials found")
+            }
+        }
+    }
+
+    /// Load credentials for a specific profile source (used by switchAccount).
+    /// Falls back to the default cascade if the source yields no token.
+    /// Both branches are non-blocking (off-main-thread I/O, mutations dispatched back to main).
+    func loadCredentials(from source: AccountSource) {
+        switch source {
+        case .credentialsFile(let path):
+            // Disk read off main thread — same pattern as the Keychain branch
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+                let bundle = CredentialLoader.fromFile(url)
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if let b = bundle {
+                        self.accessToken = b.accessToken
+                        self.refreshToken = b.refreshToken
+                        self.tokenExpiresAt = b.expiresAt
+                        self.subscriptionType = b.subscriptionType
+                        self.credentialSource = .file
+                        self.isAuthenticated = true
+                        Log.info("Credentials loaded from file for profile (type: \(b.subscriptionType))")
+                        return
+                    }
+                    Log.warn("loadCredentials(from:) file miss — reverting to default cascade")
+                    self.loadCredentials()
+                }
+            }
+
+        case .keychainService(let name):
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                let json = Self.readKeychainViaSecurityCLI(service: name, account: nil)
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if let json,
+                       let oauth = json["claudeAiOauth"] as? [String: Any],
+                       let token = oauth["accessToken"] as? String, !token.isEmpty {
+                        self.accessToken = token
+                        self.refreshToken = oauth["refreshToken"] as? String
+                        self.tokenExpiresAt = oauth["expiresAt"] as? Double
+                        self.subscriptionType = oauth["subscriptionType"] as? String ?? ""
+                        self.credentialSource = .keychain
+                        self.isAuthenticated = true
+                        Log.info("Credentials loaded from Keychain for profile (type: \(self.subscriptionType))")
+                        return
+                    }
+                    Log.warn("loadCredentials(from:) keychain miss for \(name) — reverting to default cascade")
+                    self.loadCredentials()
+                }
             }
         }
     }

--- a/Sources/CredentialLoader.swift
+++ b/Sources/CredentialLoader.swift
@@ -1,0 +1,95 @@
+// CredentialLoader.swift
+// Stateless credential resolution: one AccountSource → one CredentialBundle.
+// Does NOT mutate AuthManager — safe to call from background threads for any profile.
+// Based on Claude God (MIT © 2025 Lucas Charvolin).
+
+import Foundation
+
+// MARK: - Credential bundle
+
+struct CredentialBundle {
+    let accessToken: String
+    let refreshToken: String?
+    let expiresAt: Double?
+    let subscriptionType: String
+}
+
+// MARK: - Loader
+
+enum CredentialLoader {
+
+    /// Resolve credentials for the given source. Returns nil if not found or invalid.
+    /// Off-main-thread safe — does not access any @Published properties.
+    static func load(from source: AccountSource) -> CredentialBundle? {
+        switch source {
+        case .keychainService(let name):
+            return fromKeychain(service: name)
+        case .credentialsFile(let path):
+            let expanded = (path as NSString).expandingTildeInPath
+            return fromFile(URL(fileURLWithPath: expanded))
+        }
+    }
+
+    // MARK: - File
+
+    static func fromFile(_ url: URL) -> CredentialBundle? {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = oauthDict(from: json),
+              let token = oauth["accessToken"] as? String, !token.isEmpty
+        else { return nil }
+        return CredentialBundle(
+            accessToken: token,
+            refreshToken: oauth["refreshToken"] as? String,
+            expiresAt: oauth["expiresAt"] as? Double,
+            subscriptionType: oauth["subscriptionType"] as? String ?? ""
+        )
+    }
+
+    // MARK: - Keychain (no-prompt CLI path)
+
+    private static func fromKeychain(service: String) -> CredentialBundle? {
+        guard let json = readKeychainViaSecurityCLI(service: service),
+              let oauth = oauthDict(from: json),
+              let token = oauth["accessToken"] as? String, !token.isEmpty
+        else { return nil }
+        return CredentialBundle(
+            accessToken: token,
+            refreshToken: oauth["refreshToken"] as? String,
+            expiresAt: oauth["expiresAt"] as? Double,
+            subscriptionType: oauth["subscriptionType"] as? String ?? ""
+        )
+    }
+
+    private static func readKeychainViaSecurityCLI(service: String) -> [String: Any]? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = ["find-generic-password", "-s", service, "-w"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0,
+                  let trimmed = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                      .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty,
+                  let jsonData = trimmed.data(using: .utf8),
+                  let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+            else { return nil }
+            return json
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Extract the oauthAccount dict, supporting both key variants Claude Code has used.
+    private static func oauthDict(from json: [String: Any]) -> [String: Any]? {
+        if let o = json["claudeAiOauth"] as? [String: Any] { return o }
+        if let o = json["oauthAccount"]  as? [String: Any] { return o }
+        return nil
+    }
+}

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -501,15 +501,16 @@ struct MenuBarView: View {
             SHCard {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        SHLabel("Accounts")
+                        SHLabel("Profiles")
                         Spacer()
                         SHButton(label: "Add", icon: "plus", style: .ghost) {
                             let label = manager.accounts.isEmpty ? "Default" : "Account \(manager.accounts.count + 1)"
-                            manager.addAccount(label: label, path: AuthManager.credentialsPath.path)
+                            manager.addAccount(label: label,
+                                               source: .credentialsFile(AuthManager.credentialsPath.path))
                         }
                     }
                     if manager.accounts.isEmpty {
-                        Text("Using default credentials. Add accounts to switch between profiles.")
+                        Text("No profiles found. Add ~/.claude/profiles.json to enable multi-profile quota tracking.")
                             .font(.system(size: 11))
                             .foregroundColor(.secondary)
                     } else {
@@ -520,6 +521,14 @@ struct MenuBarView: View {
                                     .frame(width: 6, height: 6)
                                 Text(account.label)
                                     .font(.system(size: 11, weight: index == manager.activeAccountIndex ? .semibold : .regular))
+                                // Per-profile utilization badge from background polling
+                                if let pq = manager.quotasByProfile[account.id],
+                                   let worst = pq.quotas.map(\.utilization).max() {
+                                    Text("\(Int(worst))%")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(UsageLevel(utilization: worst).color)
+                                        .opacity(pq.isStale ? 0.5 : 1.0)
+                                }
                                 Spacer()
                                 if index != manager.activeAccountIndex {
                                     SHButton(label: "Switch", style: .ghost) {

--- a/Sources/ProfileRegistry.swift
+++ b/Sources/ProfileRegistry.swift
@@ -1,0 +1,228 @@
+// ProfileRegistry.swift
+// Discovers Claude Code profiles from ~/.claude/profiles.json and correlates
+// each profile directory to its Keychain service entry via token comparison.
+// Watches the registry file for changes and republishes the profile list.
+// Based on Claude God (MIT © 2025 Lucas Charvolin).
+
+import Foundation
+import Combine
+import Security
+
+// MARK: - Discovered profile
+
+struct DiscoveredProfile: Identifiable, Equatable {
+    let id: String          // registry key, e.g. "personal"
+    let displayName: String // capitalized for display, e.g. "Personal"
+    let dir: String         // expanded absolute path, e.g. "/Users/x/.claude-personal"
+    let source: AccountSource
+}
+
+// MARK: - Registry manager
+
+final class ProfileRegistryManager: ObservableObject {
+    @Published private(set) var profiles: [DiscoveredProfile] = []
+
+    static let registryURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude/profiles.json")
+
+    private var watcher: DispatchSourceFileSystemObject?
+    private var debounce: DispatchWorkItem?
+
+    // Cache maps profileDir → AccountSource so the Keychain scan only runs once per dir.
+    private static let cacheKey = "profileSourceCache_v1"
+
+    // MARK: - Lifecycle
+
+    func start() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            self?.reloadInternal()
+            DispatchQueue.main.async { [weak self] in self?.startWatching() }
+        }
+    }
+
+    func reload() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            self?.reloadInternal()
+        }
+    }
+
+    private func reloadInternal() {
+        let raw = loadProfiles()
+        guard !raw.isEmpty else {
+            DispatchQueue.main.async { [weak self] in self?.profiles = [] }
+            return
+        }
+        let resolved = resolveSourcesWithCache(raw)
+        DispatchQueue.main.async { [weak self] in self?.profiles = resolved }
+    }
+
+    // MARK: - Profile discovery
+
+    private func loadProfiles() -> [(id: String, dir: String)] {
+        guard let data = try? Data(contentsOf: Self.registryURL),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [] }
+        return obj.compactMap { key, value in
+            guard let entry = value as? [String: Any],
+                  let rawDir = entry["dir"] as? String else { return nil }
+            return (id: key, dir: (rawDir as NSString).expandingTildeInPath)
+        }.sorted { $0.id < $1.id }
+    }
+
+    private func resolveSourcesWithCache(_ raw: [(id: String, dir: String)]) -> [DiscoveredProfile] {
+        var cache = loadCache()
+
+        // Enumerate Keychain once for the entire batch (one scan, not N scans)
+        let keychainTokens = enumerateKeychainServices()
+
+        var changed = false
+        let result = raw.map { profile -> DiscoveredProfile in
+            // Use cached source if Keychain still has that service
+            if let cached = cache[profile.dir],
+               case .keychainService(let svc) = cached,
+               keychainTokens[svc] != nil {
+                return DiscoveredProfile(id: profile.id,
+                                         displayName: formatName(profile.id),
+                                         dir: profile.dir, source: cached)
+            }
+            // Token-correlation: find the Keychain entry whose token matches this profile's creds
+            let source = resolveSource(profileDir: profile.dir, keychainTokens: keychainTokens)
+            if cache[profile.dir] != source { cache[profile.dir] = source; changed = true }
+            return DiscoveredProfile(id: profile.id,
+                                     displayName: formatName(profile.id),
+                                     dir: profile.dir, source: source)
+        }
+        if changed { saveCache(cache) }
+        return result
+    }
+
+    private func resolveSource(profileDir: String, keychainTokens: [String: String]) -> AccountSource {
+        // Try .claude.json first (official credential file when CLAUDE_CONFIG_DIR is set)
+        for credFile in ["\(profileDir)/.claude.json", "\(profileDir)/.credentials.json"] {
+            if let token = accessToken(fromFile: credFile),
+               let (service, _) = keychainTokens.first(where: { $0.value == token }) {
+                return .keychainService(service)
+            }
+        }
+        // Fallback: use the credentials file directly
+        let claudeJSON = "\(profileDir)/.claude.json"
+        return .credentialsFile(
+            FileManager.default.fileExists(atPath: claudeJSON)
+                ? claudeJSON
+                : "\(profileDir)/.credentials.json"
+        )
+    }
+
+    private func accessToken(fromFile path: String) -> String? {
+        let url = URL(fileURLWithPath: path)
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        if let o = json["claudeAiOauth"] as? [String: Any],
+           let t = o["accessToken"] as? String, !t.isEmpty { return t }
+        if let o = json["oauthAccount"] as? [String: Any],
+           let t = o["accessToken"] as? String, !t.isEmpty { return t }
+        return nil
+    }
+
+    // MARK: - Keychain enumeration
+
+    /// Returns [serviceName: accessToken] for all "Claude Code-credentials*" Keychain entries.
+    /// Reuses the same SecItemCopyMatching pattern as AuthManager.loadBestKeychainEntryWithPrefix.
+    private func enumerateKeychainServices() -> [String: String] {
+        let listQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecReturnRef as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var listRaw: CFTypeRef?
+        guard SecItemCopyMatching(listQuery as CFDictionary, &listRaw) == errSecSuccess,
+              let items = listRaw as? [[String: Any]] else { return [:] }
+
+        var result: [String: String] = [:]
+        for item in items {
+            guard let service = item[kSecAttrService as String] as? String,
+                  service.hasPrefix("Claude Code-credentials") else { continue }
+            let account = item[kSecAttrAccount as String] as? String ?? ""
+            var fetchQ: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne
+            ]
+            if !account.isEmpty { fetchQ[kSecAttrAccount as String] = account }
+            var dataRaw: CFTypeRef?
+            guard SecItemCopyMatching(fetchQ as CFDictionary, &dataRaw) == errSecSuccess,
+                  let data = dataRaw as? Data,
+                  let trimmed = String(data: data, encoding: .utf8)?
+                      .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty,
+                  let jsonData = trimmed.data(using: .utf8),
+                  let json = (try? JSONSerialization.jsonObject(with: jsonData)) as? [String: Any],
+                  let oauth = json["claudeAiOauth"] as? [String: Any],
+                  let token = oauth["accessToken"] as? String, !token.isEmpty
+            else { continue }
+            result[service] = token
+        }
+        return result
+    }
+
+    // MARK: - Source cache
+
+    private func loadCache() -> [String: AccountSource] {
+        guard let data = UserDefaults.standard.data(forKey: Self.cacheKey),
+              let decoded = try? JSONDecoder().decode([String: AccountSource].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+
+    private func saveCache(_ cache: [String: AccountSource]) {
+        if let data = try? JSONEncoder().encode(cache) {
+            UserDefaults.standard.set(data, forKey: Self.cacheKey)
+        }
+    }
+
+    // MARK: - File watcher (mirrors AuthManager.startWatchingCredentials)
+
+    private func startWatching() {
+        stopWatching()
+        let path = Self.registryURL.path
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }   // File absent — no watch needed; reload() on next start()
+
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename, .delete],
+            queue: DispatchQueue.main
+        )
+        src.setEventHandler { [weak self] in
+            // Debounce: editors write-then-rename; settle for 400ms before reload
+            self?.debounce?.cancel()
+            let work = DispatchWorkItem { [weak self] in
+                // Re-arm watcher after atomic rename (which invalidates the old fd)
+                self?.stopWatching()
+                self?.reload()
+                self?.startWatching()
+            }
+            self?.debounce = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
+        }
+        src.setCancelHandler { close(fd) }
+        src.resume()
+        watcher = src
+    }
+
+    private func stopWatching() {
+        watcher?.cancel()
+        watcher = nil
+    }
+
+    deinit { stopWatching() }
+
+    // MARK: - Helpers
+
+    private func formatName(_ key: String) -> String {
+        key.split(separator: "-").map { $0.capitalized }.joined(separator: " ")
+    }
+}

--- a/Sources/QuotaPoller.swift
+++ b/Sources/QuotaPoller.swift
@@ -1,0 +1,69 @@
+// QuotaPoller.swift
+// Polls quota data for all configured accounts in the background.
+// Uses CredentialLoader (off-main-thread safe) and delegates HTTP fetching to UsageManager.
+// Based on Claude God (MIT © 2025 Lucas Charvolin).
+
+import Foundation
+
+// MARK: - Per-profile quota snapshot
+
+struct ProfileQuota {
+    let accountID: UUID
+    let label: String
+    let quotas: [UsageQuota]
+    let fetchedAt: Date
+    let error: String?
+
+    var isStale: Bool { Date().timeIntervalSince(fetchedAt) > 180 }
+    var worstUtilization: Double { quotas.map(\.utilization).max() ?? 0 }
+}
+
+// MARK: - Poller
+
+final class QuotaPoller {
+    private var isPolling = false
+
+    /// Fan out a background fetch for each account. Calls `onResult` on the main queue
+    /// for each account as results arrive (not batched — callers must handle concurrent updates).
+    func pollAll(accounts: [AccountInfo],
+                 onResult: @escaping (UUID, ProfileQuota) -> Void) {
+        guard !isPolling, !accounts.isEmpty else { return }
+        isPolling = true
+
+        let group = DispatchGroup()
+
+        for account in accounts {
+            let accountID = account.id
+            let label = account.label
+
+            group.enter()
+            DispatchQueue.global(qos: .utility).async {
+                guard let bundle = CredentialLoader.load(from: account.source) else {
+                    Log.warn("QuotaPoller: no credentials for \(label)")
+                    let pq = ProfileQuota(accountID: accountID, label: label,
+                                          quotas: [], fetchedAt: Date(),
+                                          error: "No credentials found")
+                    DispatchQueue.main.async { onResult(accountID, pq) }
+                    group.leave()
+                    return
+                }
+
+                UsageManager.fetchQuotasStateless(token: bundle.accessToken) { quotas in
+                    let pq = ProfileQuota(
+                        accountID: accountID,
+                        label: label,
+                        quotas: quotas ?? [],
+                        fetchedAt: Date(),
+                        error: quotas == nil ? "Fetch failed" : nil
+                    )
+                    DispatchQueue.main.async { onResult(accountID, pq) }
+                    group.leave()
+                }
+            }
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            self?.isPolling = false
+        }
+    }
+}

--- a/Sources/SessionAnalyzer.swift
+++ b/Sources/SessionAnalyzer.swift
@@ -19,6 +19,7 @@ enum UDKey {
     static let sessionAnnotations = "sessionAnnotations"
     static let accounts = "accounts"
     static let activeAccountIndex = "activeAccountIndex"
+    static let profileSourceCache = "profileSourceCache_v1"
     static let notifiedThresholds = "notifiedThresholds"
     static let autoReconnect = "autoReconnect"
     static let widgetQuotas = "widgetQuotas"

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -1,5 +1,6 @@
 // UsageManager.swift
 // Orchestrates usage data: API calls, stats, preferences, notifications
+// Based on Claude God (MIT © 2025 Lucas Charvolin).
 
 import Foundation
 import Combine
@@ -91,7 +92,37 @@ struct SessionAnnotation: Codable {
 struct AccountInfo: Identifiable, Codable {
     var id = UUID()
     var label: String       // e.g. "Work", "Personal"
-    var credentialsPath: String
+    var source: AccountSource
+
+    // Back-compat: old records encoded credentialsPath: String instead of source: AccountSource
+    private enum CodingKeys: String, CodingKey {
+        case id, label, source, credentialsPath
+    }
+
+    init(id: UUID = UUID(), label: String, source: AccountSource) {
+        self.id = id; self.label = label; self.source = source
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id    = (try? c.decode(UUID.self,   forKey: .id))    ?? UUID()
+        label =  try  c.decode(String.self, forKey: .label)
+        if let s = try? c.decode(AccountSource.self, forKey: .source) {
+            source = s
+        } else if let path = try? c.decode(String.self, forKey: .credentialsPath), !path.isEmpty {
+            source = .credentialsFile(path)   // migrate legacy field
+        } else {
+            source = .credentialsFile(AuthManager.credentialsPath.path)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id,     forKey: .id)
+        try c.encode(label,  forKey: .label)
+        try c.encode(source, forKey: .source)
+        // credentialsPath is legacy decode-only — not re-encoded
+    }
 }
 
 // MARK: - Seuils de couleur partagés
@@ -326,6 +357,12 @@ class UsageManager: ObservableObject {
             UserDefaults.standard.set(activeAccountIndex, forKey: UDKey.activeAccountIndex)
         }
     }
+
+    /// Per-account quota snapshots from background polling. Keyed by AccountInfo.id.
+    @Published var quotasByProfile: [UUID: ProfileQuota] = [:]
+
+    let profileRegistry = ProfileRegistryManager()
+    private let quotaPoller = QuotaPoller()
 
     // MARK: - Timeline
 
@@ -812,7 +849,7 @@ class UsageManager: ObservableObject {
             self.sessionAnnotations = [:]
         }
 
-        // Load accounts
+        // Load accounts (migrates legacy credentialsPath → AccountSource via custom init(from:))
         if let data = ud.data(forKey: UDKey.accounts),
            let decoded = try? JSONDecoder().decode([AccountInfo].self, from: data) {
             self.accounts = decoded
@@ -856,6 +893,27 @@ class UsageManager: ObservableObject {
 
         auth.loadCredentials()
         auth.startWatchingCredentials()
+
+        // Start profile registry (reads ~/.claude/profiles.json, watches for changes)
+        profileRegistry.start()
+
+        // Seed accounts from profiles.json on first launch (when no accounts are persisted)
+        profileRegistry.$profiles
+            .filter { !$0.isEmpty }
+            .first()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] discovered in
+                guard let self, self.accounts.isEmpty else { return }
+                self.accounts = discovered.map {
+                    AccountInfo(label: $0.displayName, source: $0.source)
+                }
+                Log.info("Auto-discovered \(self.accounts.count) profile(s) from profiles.json")
+            }.store(in: &cancellables)
+
+        // Forward registry changes to UI
+        profileRegistry.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }.store(in: &cancellables)
 
         // Auto-connect when credentials appear via file watcher
         auth.objectWillChange.sink { [weak self] _ in
@@ -1323,6 +1381,7 @@ class UsageManager: ObservableObject {
             Log.info("Rate limit cooldown expired, resetting backoff")
         }
         refreshInternal()
+        pollAllProfiles()
     }
 
     private func refreshInternal() {
@@ -1911,23 +1970,82 @@ class UsageManager: ObservableObject {
 
     // MARK: - Multi-account
 
-    func addAccount(label: String, path: String) {
-        accounts.append(AccountInfo(label: label, credentialsPath: path))
+    func addAccount(label: String, source: AccountSource) {
+        accounts.append(AccountInfo(label: label, source: source))
     }
 
     func switchAccount(index: Int) {
         guard index >= 0 && index < accounts.count else { return }
         activeAccountIndex = index
-        auth.loadCredentials()
+        // Wire the selected account's credential source into AuthManager (the core bug fix)
+        auth.loadCredentials(from: accounts[index].source)
         // Don't clear quotas — keep old data until new ones arrive
         refresh()
     }
 
     func removeAccount(at index: Int) {
         guard index >= 0 && index < accounts.count else { return }
+        let removedID = accounts[index].id
         accounts.remove(at: index)
+        quotasByProfile.removeValue(forKey: removedID)
         if activeAccountIndex >= accounts.count {
             activeAccountIndex = max(0, accounts.count - 1)
+        }
+    }
+
+    // MARK: - Background multi-profile polling
+
+    private func pollAllProfiles() {
+        let snapshot = accounts
+        guard snapshot.count > 1 else { return }   // Single profile: active fetch is enough
+        quotaPoller.pollAll(accounts: snapshot) { [weak self] id, pq in
+            self?.quotasByProfile[id] = pq
+        }
+    }
+
+    /// Stateless quota fetch: given a bearer token, fetches and returns [UsageQuota] without
+    /// mutating any @Published state. Called by QuotaPoller for background profile polling.
+    static func fetchQuotasStateless(token: String,
+                                     completion: @escaping ([UsageQuota]?) -> Void) {
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token.trimmingCharacters(in: .whitespacesAndNewlines))",
+                         forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("ClaudeGod",        forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 15
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data, error == nil,
+                  let httpResp = response as? HTTPURLResponse, httpResp.statusCode == 200,
+                  let decoded = try? JSONDecoder().decode(OAuthUsageResponse.self, from: data)
+            else {
+                completion(nil)
+                return
+            }
+            completion(Self.buildQuotaList(from: decoded))
+        }.resume()
+    }
+
+    private static func buildQuotaList(from response: OAuthUsageResponse) -> [UsageQuota] {
+        let defs: [(quota: QuotaData?, label: String, icon: String)] = [
+            (response.fiveHour,          "Session (5h)",        "bolt.fill"),
+            (response.sevenDay,          "Weekly (all)",        "calendar"),
+            (response.sevenDaySonnet,    "Sonnet (7d)",         "sparkle"),
+            (response.sevenDayOpus,      "Opus (7d)",           "star.fill"),
+            (response.sevenDayOmelette,  "Claude Design (7d)",  "paintbrush.fill"),
+            (response.sevenDayCowork,    "Cowork (7d)",         "person.2.fill"),
+            (response.sevenDayOauthApps, "OAuth Apps (7d)",     "app.connected.to.app.below.fill"),
+            (response.iguanaNecktie,     "Extended (7d)",       "sparkles"),
+            (response.omelettPromotional,"Design Promo (7d)",   "gift.fill"),
+        ]
+        return defs.compactMap { def in
+            guard let q = def.quota else { return nil }
+            return UsageQuota(label: def.label, icon: def.icon,
+                              utilization: q.utilization,
+                              resetsAt: q.resetsAt.flatMap(Formatters.parseISO))
         }
     }
 


### PR DESCRIPTION
## Summary

- **AccountSource enum (FR-1)**: Generalizes `AccountInfo.credentialsPath: String` into `.keychainService(String) | .credentialsFile(String)` — back-compat `Codable` migration, existing persisted accounts decode without data loss
- **ProfileRegistryManager**: Reads `~/.claude/profiles.json`, discovers which Keychain service entry matches each profile via token-correlation, caches results, watches the file live with a debounced `DispatchSourceFileSystemObject`
- **switchAccount fix**: Was always calling `auth.loadCredentials()` (reads the static default path). Now calls `auth.loadCredentials(from: accounts[index].source)` — the core bug
- **Background quota polling**: `QuotaPoller` fans out one `UsageManager.fetchQuotasStateless` call per account each auto-refresh cycle; results land in `UsageManager.quotasByProfile[UUID]`
- **Per-profile utilization badge**: Worst-quota %, dimmed when stale, visible in the Accounts settings card

## ADR Compliance

- MIT © 2025 Lucas Charvolin preserved on all modified and new files (ADR-G005 §6)
- Credentials read per-profile via their own `AccountSource`, never copied across profiles (ADR-D002)
- Vendored submodule `docs/reference/claude-god/` unmodified (ADR-G005)
- No `package.json` version bump, no git tags created (ADR-G001)

## Test Plan

- [ ] Build succeeds (`xcodebuild -scheme ClaudeGod build`)
- [ ] App launches with default single-profile behavior unchanged (no `profiles.json` present)
- [ ] With `~/.claude/profiles.json` populated: Profiles card shows auto-discovered profiles on first launch
- [ ] Switching profiles loads the correct profile's token (verify by checking displayed quota changes)
- [ ] Background polling populates per-profile utilization badges after first auto-refresh cycle
- [ ] Adding/removing profiles to `profiles.json` is picked up without app restart

## Tracks

Closes VisionaryStudios/vsify-claude-profiles#14

🤖 Generated with [Claude Code](https://claude.com/claude-code)