### PR TITLE
Fix repeated keychain prompt for suffixed credential entries

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -398,24 +398,8 @@ class AuthManager: ObservableObject {
                   service.hasPrefix(prefix) else { continue }
             let account = item[kSecAttrAccount as String] as? String ?? ""
 
-            var fetchQuery: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: service,
-                kSecReturnData as String: true,
-                kSecMatchLimit as String: kSecMatchLimitOne
-            ]
-            if !account.isEmpty {
-                fetchQuery[kSecAttrAccount as String] = account
-            }
-
-            var dataRaw: CFTypeRef?
-            guard SecItemCopyMatching(fetchQuery as CFDictionary, &dataRaw) == errSecSuccess,
-                  let data = dataRaw as? Data,
-                  let trimmed = String(data: data, encoding: .utf8)?
-                      .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !trimmed.isEmpty,
-                  let jsonData = trimmed.data(using: .utf8),
-                  let json = (try? JSONSerialization.jsonObject(with: jsonData)) as? [String: Any],
+            // ponytail: use CLI (no-prompt) instead of SecItemCopyMatching+kSecReturnData (prompts)
+            guard let json = readKeychainViaSecurityCLI(service: service, account: account.isEmpty ? nil : account),
                   let oauth = json["claudeAiOauth"] as? [String: Any],
                   let token = oauth["accessToken"] as? String, !token.isEmpty
             else { continue }


### PR DESCRIPTION
Fixes #30

## What

Newer Claude Code versions store credentials under a suffixed keychain service (`Claude Code-credentials-<uuid>`). `loadBestKeychainEntryWithPrefix` was using `SecItemCopyMatching + kSecReturnData` to fetch each entry's password — this triggers macOS's keychain access dialog on every credential read, causing a spam loop.

## Fix

Reuse the existing `readKeychainViaSecurityCLI(service:account:)` helper for the per-item data fetch. It calls `/usr/bin/security find-generic-password` with the exact service name (discovered from the non-prompting list query), bypassing the Security framework dialog entirely.

## Change

```
Sources/AuthManager.swift | 20 +-------
1 file changed, 2 insertions(+), 18 deletions(-)
```

No new dependencies. Build verified.