### PR TITLE
feat: model-scoped weekly quotas (e.g. Fable) from the limits array

### DIFF
--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -139,6 +139,7 @@ private struct OAuthUsageResponse: Decodable {
     let iguanaNecktie: QuotaData?
     let omelettPromotional: QuotaData?
     let extraUsage: ExtraUsageData?
+    let limits: [LimitEntry]?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -151,6 +152,35 @@ private struct OAuthUsageResponse: Decodable {
         case iguanaNecktie = "iguana_necktie"
         case omelettPromotional = "omelette_promotional"
         case extraUsage = "extra_usage"
+        case limits
+    }
+}
+
+/// Entry in the `limits` array — model-scoped quotas (e.g. the Fable weekly
+/// limit) only appear here, not as top-level buckets.
+private struct LimitEntry: Decodable {
+    let kind: String
+    let percent: Double?
+    let resetsAt: String?
+    let scope: LimitScope?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case percent
+        case resetsAt = "resets_at"
+        case scope
+    }
+}
+
+private struct LimitScope: Decodable {
+    let model: LimitScopeModel?
+}
+
+private struct LimitScopeModel: Decodable {
+    let displayName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
     }
 }
 
@@ -1627,6 +1657,19 @@ class UsageManager: ObservableObject {
             (response.omelettPromotional,"Design Promo (7d)",   "gift.fill"),
         ]
 
+        let scopedWeeklyQuotas = (response.limits ?? [])
+            .filter { $0.kind == "weekly_scoped" }
+            .compactMap { entry -> UsageQuota? in
+                guard let name = entry.scope?.model?.displayName,
+                      let percent = entry.percent else { return nil }
+                return UsageQuota(
+                    label: "Weekly (\(name))",
+                    icon: "book.fill",
+                    utilization: percent,
+                    resetsAt: entry.resetsAt.flatMap(Formatters.parseISO)
+                )
+            }
+
         quotas = quotaDefs.compactMap { def in
             guard let q = def.quota else { return nil }
             return UsageQuota(
@@ -1635,7 +1678,7 @@ class UsageManager: ObservableObject {
                 utilization: q.utilization,
                 resetsAt: q.resetsAt.flatMap(Formatters.parseISO)
             )
-        }
+        } + scopedWeeklyQuotas
         extraUsage = response.extraUsage
         Log.info("Parsed \(quotas.count) quotas, extraUsage=\(response.extraUsage != nil)")
     }


### PR DESCRIPTION
## What

Shows model-scoped weekly limits — currently the **Fable** weekly quota on Max or greater plans — in the usage list, matching claude.ai's "Weekly limits" section.

## Why

These limits have no top-level bucket in the OAuth usage response (no `seven_day_fable`); they only appear in the `limits` array:

```json
{ "kind": "weekly_scoped", "percent": 6, "resets_at": "...",
  "scope": { "model": { "display_name": "Fable" } } }
```

## How

Decode `limits` in `OAuthUsageResponse` and map each `weekly_scoped` entry to a `UsageQuota` labeled `"Weekly (<name>)"` → "Weekly (Fable)", so it lines up with "Weekly (all)" in the popover. Everything downstream (popover, notifications, alert rules, rings, widget) iterates `quotas` generically, so this is the only change. Legacy parsing untouched; accounts without scoped limits (`limits` empty or absent) see no difference. The menu bar "W %" still resolves to "Weekly (all)" — scoped quotas are appended after the legacy buckets, so the existing first-match lookup is unaffected.

## Testing

Verified against my live `/api/oauth/usage` response — "Weekly (Fable)" renders with the same % and reset time as claude.ai. Release build + launch on macOS; one file changed.

<img width="395" height="244" alt="Screenshot 2026-07-22 at 2 39 04 PM" src="https://github.com/user-attachments/assets/b792e0e6-e060-414a-9fce-911ff2399934" />

