### PR TITLE
Fix permanent "Session expired": prefer freshest credentials, allow input in sign-in terminal

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -40,52 +40,94 @@ class AuthManager: ObservableObject {
     // MARK: - Credential loading
 
     func loadCredentials() {
-        // 1. File ~/.claude/.credentials.json
-        if let data = try? Data(contentsOf: Self.credentialsPath),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let oauth = json["claudeAiOauth"] as? [String: Any],
-           let token = oauth["accessToken"] as? String, !token.isEmpty {
-            accessToken = token
-            refreshToken = oauth["refreshToken"] as? String
-            tokenExpiresAt = oauth["expiresAt"] as? Double
-            subscriptionType = oauth["subscriptionType"] as? String ?? ""
-            credentialSource = .file
-            isAuthenticated = true
-            Log.info("Credentials loaded from file (type: \(subscriptionType))")
+        resolveCredentials { _ in }
+    }
+
+    /// Credentials JSON from `~/.claude/.credentials.json`, or nil if absent/unusable.
+    private static func fileCredentialsJSON() -> [String: Any]? {
+        guard let data = try? Data(contentsOf: credentialsPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let token = oauth["accessToken"] as? String, !token.isEmpty
+        else { return nil }
+        return json
+    }
+
+    private static func oauthExpiry(_ json: [String: Any]) -> Double {
+        ((json["claudeAiOauth"] as? [String: Any])?["expiresAt"] as? Double) ?? 0
+    }
+
+    /// Adopt a credentials payload. Returns false if it carries no usable token.
+    @discardableResult
+    private func adopt(_ json: [String: Any], source: CredentialSource) -> Bool {
+        guard let oauth = json["claudeAiOauth"] as? [String: Any],
+              let token = oauth["accessToken"] as? String, !token.isEmpty
+        else { return false }
+        accessToken = token
+        refreshToken = oauth["refreshToken"] as? String
+        tokenExpiresAt = oauth["expiresAt"] as? Double
+        subscriptionType = oauth["subscriptionType"] as? String ?? ""
+        credentialSource = source
+        isAuthenticated = true
+        return true
+    }
+
+    /// Resolve credentials from the freshest available source.
+    ///
+    /// The file is only authoritative while its token is still valid: newer Claude Code
+    /// versions refresh into the Keychain (per-project entries) and leave a stale
+    /// `.credentials.json` behind. Preferring the file unconditionally pinned the app to
+    /// an expired token, so re-signing in never cleared "Session expired".
+    private func resolveCredentials(completion: @escaping (Bool) -> Void) {
+        let previousToken = accessToken
+        let fileJSON = Self.fileCredentialsJSON()
+
+        // Fast path: file token still valid — no Keychain round-trip needed.
+        if let fileJSON, Self.hasFreshOAuthToken(fileJSON), adopt(fileJSON, source: .file) {
+            if accessToken != previousToken { Log.info("Credentials loaded from file (type: \(subscriptionType))") }
+            completion(true)
             return
         }
 
-        // 2. Keychain — load off main thread to avoid blocking UI
+        // Keychain — read off the main thread to avoid blocking UI.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let keychainJSON = Self.loadFromKeychain()
             DispatchQueue.main.async {
                 guard let self else { return }
-                if let keychainJSON,
-                   let oauth = keychainJSON["claudeAiOauth"] as? [String: Any],
-                   let token = oauth["accessToken"] as? String, !token.isEmpty {
-                    self.accessToken = token
-                    self.refreshToken = oauth["refreshToken"] as? String
-                    self.tokenExpiresAt = oauth["expiresAt"] as? Double
-                    self.subscriptionType = oauth["subscriptionType"] as? String ?? ""
-                    self.credentialSource = .keychain
-                    self.isAuthenticated = true
-                    Log.info("Credentials loaded from Keychain (type: \(self.subscriptionType))")
+
+                // Both sources may be stale; take whichever token lives longest.
+                let candidates: [([String: Any], CredentialSource)] = [
+                    keychainJSON.map { ($0, CredentialSource.keychain) },
+                    fileJSON.map { ($0, CredentialSource.file) }
+                ].compactMap { $0 }
+
+                if let best = candidates.max(by: { Self.oauthExpiry($0.0) < Self.oauthExpiry($1.0) }),
+                   self.adopt(best.0, source: best.1) {
+                    if self.accessToken != previousToken {
+                        Log.info("Credentials loaded from \(best.1.rawValue) (type: \(self.subscriptionType))")
+                    }
+                    completion(true)
                     return
                 }
 
-                // 3. Environment variable
                 if let envToken = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"],
                    !envToken.isEmpty {
                     self.accessToken = envToken
                     self.credentialSource = .environment
                     self.isAuthenticated = true
                     Log.info("Credentials loaded from environment")
+                    completion(true)
                     return
                 }
 
-                self.credentialSource = .none
-                self.isAuthenticated = false
-                Log.warn("No credentials found")
+                Log.warn("No credentials found in file or Keychain")
+                // Keep a previously loaded token: a transient read failure shouldn't
+                // sign the user out.
+                if previousToken == nil {
+                    self.credentialSource = .none
+                    self.isAuthenticated = false
+                }
+                completion(self.isAuthenticated)
             }
         }
     }
@@ -104,52 +146,11 @@ class AuthManager: ObservableObject {
         return Date() >= expiresDate
     }
 
-    /// Reload credentials from disk first, then keychain as fallback.
-    /// On macOS, Claude Code may store credentials exclusively in keychain
-    /// (deleting .credentials.json), so we must check both sources.
+    /// Reload credentials, preferring whichever source holds the longest-lived token.
+    /// On macOS, Claude Code may store credentials exclusively in the Keychain
+    /// (or refresh only there), so both sources must be compared.
     func reloadCredentials(completion: @escaping (Bool) -> Void) {
-        let previousToken = accessToken
-
-        // 1. Try file first
-        if let data = try? Data(contentsOf: Self.credentialsPath),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let oauth = json["claudeAiOauth"] as? [String: Any],
-           let token = oauth["accessToken"] as? String, !token.isEmpty {
-            accessToken = token
-            refreshToken = oauth["refreshToken"] as? String
-            tokenExpiresAt = oauth["expiresAt"] as? Double
-            subscriptionType = oauth["subscriptionType"] as? String ?? ""
-            credentialSource = .file
-            isAuthenticated = true
-            let changed = accessToken != previousToken
-            if changed { Log.info("Credentials reloaded from file") }
-            completion(true)
-            return
-        }
-
-        // 2. Fallback to keychain (off main thread)
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let keychainJSON = Self.loadFromKeychain()
-            DispatchQueue.main.async {
-                guard let self else { return }
-                if let keychainJSON,
-                   let oauth = keychainJSON["claudeAiOauth"] as? [String: Any],
-                   let token = oauth["accessToken"] as? String, !token.isEmpty {
-                    self.accessToken = token
-                    self.refreshToken = oauth["refreshToken"] as? String
-                    self.tokenExpiresAt = oauth["expiresAt"] as? Double
-                    self.subscriptionType = oauth["subscriptionType"] as? String ?? ""
-                    self.credentialSource = .keychain
-                    self.isAuthenticated = true
-                    let changed = self.accessToken != previousToken
-                    if changed { Log.info("Credentials reloaded from Keychain") }
-                    completion(true)
-                } else {
-                    Log.warn("No credentials found in file or Keychain")
-                    completion(self.isAuthenticated)
-                }
-            }
-        }
+        resolveCredentials(completion: completion)
     }
 
     // MARK: - Silent token self-refresh

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -3580,6 +3580,7 @@ struct MenuBarView: View {
 
 struct EmbeddedTerminalView: View {
     @ObservedObject var session: TerminalSession
+    @State private var input: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -3628,6 +3629,27 @@ struct EmbeddedTerminalView: View {
                 }
             }
             .frame(height: 130)
+
+            // Input — `claude auth login` prompts for a pasted authorization code
+            if session.isRunning {
+                Divider().background(Color.white.opacity(0.08))
+                HStack(spacing: 6) {
+                    Text("›")
+                        .font(.system(size: 11, weight: .bold, design: .monospaced))
+                        .foregroundColor(.green.opacity(0.7))
+                    TextField("Paste code and press ⏎", text: $input)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.9))
+                        .onSubmit {
+                            session.send(input)
+                            input = ""
+                        }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.black.opacity(0.4))
+            }
         }
         .background(Color(red: 0.05, green: 0.05, blue: 0.05))
         .cornerRadius(8)

--- a/Sources/TerminalSession.swift
+++ b/Sources/TerminalSession.swift
@@ -79,6 +79,27 @@ final class TerminalSession: ObservableObject {
         startReading()
     }
 
+    // MARK: - Input
+
+    /// Write a line to the child process's stdin.
+    /// `claude auth login` asks the user to paste an authorization code, so the
+    /// embedded session is unusable without a way to answer it.
+    func send(_ line: String) {
+        guard masterFD >= 0, let data = (line + "\n").data(using: .utf8) else { return }
+        data.withUnsafeBytes { buffer in
+            guard let base = buffer.baseAddress else { return }
+            var written = 0
+            while written < buffer.count {
+                let n = write(masterFD, base.advanced(by: written), buffer.count - written)
+                guard n > 0 else {
+                    Log.warn("TerminalSession.send: write failed: \(String(cString: strerror(errno)))")
+                    return
+                }
+                written += n
+            }
+        }
+    }
+
     // MARK: - Stop
 
     func stop() {


### PR DESCRIPTION
Fixes #37.

Two independent bugs combined into a "Session expired" state that no amount of signing in could clear.

### 1. Credential precedence: freshest source wins

`loadCredentials()` and `reloadCredentials()` both returned the contents of `~/.claude/.credentials.json` whenever it held a non-empty `accessToken`, without ever checking expiry. Newer Claude Code versions refresh into the Keychain and leave a stale file behind, so the app pinned itself to a dead token while a valid one sat in the Keychain unread — and the expired-credential poller re-read that same dead file every 10 seconds.

Both entry points now delegate to a single `resolveCredentials(completion:)`:

* fast path — use the file only while its token is still valid (no Keychain round-trip in the common case),
* otherwise compare the best Keychain entry against the file and adopt whichever `expiresAt` is later,
* then the `CLAUDE_CODE_OAUTH_TOKEN` environment variable,
* a read that finds nothing no longer clears `isAuthenticated` when a token was already loaded, so a transient failure can't sign the user out.

This also removes the duplicated load/reload logic that had already drifted apart.

### 2. The embedded sign-in terminal accepts input

`TerminalSession` ran `claude auth login` in a PTY but had no stdin write path, so the "paste your authorization code" prompt was unanswerable and every in-app sign-in timed out. Adds `send(_:)` (line-buffered write to the master FD, handling partial writes) and a monospaced input row in `EmbeddedTerminalView`, shown while the session is running.

### Verification

* `xcodebuild -scheme ClaudeGod -configuration Release build` — succeeds.
* Ran the build against a machine in exactly this broken state (file token expired at 14:46, Keychain token still valid): before, the log read `Credentials loaded from file` followed by "Session expired"; after, it reads `Credentials loaded from Keychain` followed by `HTTP 200` and usage renders normally.
* Sign-in terminal: prompt now accepts a pasted code and the flow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
