### PR TITLE
fix: show Usage tab for extra-usage-only enterprise accounts

### DIFF
--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -68,7 +68,7 @@ struct MenuBarView: View {
                         loadingView
                     } else if let error = manager.errorMessage {
                         errorView(error)
-                    } else if !manager.quotas.isEmpty {
+                    } else if !manager.quotas.isEmpty || manager.extraUsage != nil {
                         if manager.compactMode {
                             compactUsageView
                         } else {


### PR DESCRIPTION
## What

Include `manager.extraUsage != nil` in the Usage tab's render gate (`MenuBarView.swift:71`), so the panel shows when an account has a dollar budget but no token quotas.

## Why

The Usage tab gated rendering solely on `!manager.quotas.isEmpty`, so enterprise accounts with extra usage (a dollar budget) but no token quotas fell through to the empty state, hiding their Extra Usage card.

The extra-usage-% work (d25bfce) fixed the menu bar, rings, and alerts by routing them through `allNotifiableQuotas` (which merges in the synthesized extra-usage quota), but it never updated this tab gate. As a result the tab was the one surface still keyed on raw `quotas`. Such accounts likely only ever rendered before because the API returned an incidental (effectively ignored) token quota that later went away, leaving the tab blank.

`usageView` already handles empty `quotas` cleanly: its `ForEach(manager.quotas)` renders nothing, while the peak-hours indicator and the Extra Usage card (`if let extra = manager.extraUsage`, line 808) still display.

## Testing

- `xcodegen generate && xcodebuild -scheme ClaudeGod -configuration Debug build` → **BUILD SUCCEEDED**.

No way to verify live against an Enterprise account until this is landed.