### PR TITLE
fix: color the menu bar by usage level at all thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | | Feature | Description |
 |---|---|---|
 | **Quotas** | Progress bars | Animated bars for session (5h), weekly, Sonnet & Opus quotas |
-| | Dynamic icon | Menu bar icon turns green/orange/red based on worst quota |
+| | Dynamic icon | Menu bar icon and text turn green/orange/red based on worst quota (toggle in Settings) |
 | | Live countdown | Real-time timer showing when quotas reset |
 | | Burn rate | Predicts when you'll hit the limit based on current velocity |
 | | Model advisor | Smart tips when quota imbalance is detected |

--- a/Sources/ClaudeUsageApp.swift
+++ b/Sources/ClaudeUsageApp.swift
@@ -28,7 +28,7 @@ struct ClaudeGodApp: App {
                 } else {
                     Image(systemName: manager.menuBarIcon)
                         .symbolRenderingMode(.palette)
-                        .foregroundStyle(manager.menuBarIconColor.opacity(manager.menuBarIconOpacity))
+                        .foregroundStyle(manager.menuBarTint.opacity(manager.menuBarIconOpacity))
                 }
                 if manager.isSessionActive {
                     Circle()
@@ -38,6 +38,7 @@ struct ClaudeGodApp: App {
                 if !manager.menuBarTitle.isEmpty {
                     Text(manager.menuBarTitle)
                         .monospacedDigit()
+                        .foregroundStyle(manager.menuBarTint)
                 }
             }
         }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -558,6 +558,15 @@ struct MenuBarView: View {
                     Text(manager.menuBarDisplayMode.description)
                         .shFont(11, weight: .medium, design: .monospaced)
                         .foregroundColor(.secondary)
+
+                    SHDivider()
+                    Toggle("Color by usage level", isOn: $manager.coloredMenuBar)
+                        .shFont(12)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                    Text("Tints the icon and text green under 50%, orange under 80%, red above.")
+                        .shFont(11)
+                        .foregroundColor(.secondary)
                 }
             }
 

--- a/Sources/SessionAnalyzer.swift
+++ b/Sources/SessionAnalyzer.swift
@@ -30,6 +30,7 @@ enum UDKey {
     static let ringStatLabels = "ringStatLabels"
     static let exportUsageJSON = "exportUsageJSON"
     static let statuslineInstalled = "statuslineInstalled"
+    static let coloredMenuBar = "coloredMenuBar"
 }
 
 // MARK: - Logging

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -485,6 +485,14 @@ class UsageManager: ObservableObject {
         }
     }
 
+    /// Tints the menu bar icon *and* text by usage level. Off falls back to the system
+    /// color, for users who prefer a monochrome menu bar.
+    @Published var coloredMenuBar: Bool {
+        didSet {
+            UserDefaults.standard.set(coloredMenuBar, forKey: UDKey.coloredMenuBar)
+        }
+    }
+
     @Published var dailyBudget: Double {
         didSet {
             UserDefaults.standard.set(dailyBudget, forKey: UDKey.dailyBudget)
@@ -598,22 +606,19 @@ class UsageManager: ObservableObject {
         }
     }
 
-    /// Secondary color hint for distinguishing warning (half-fill) from critical
+    /// Secondary hint distinguishing warning from critical when the menu bar is monochrome.
+    /// With tinting on, the color already carries that signal, so dimming only costs legibility.
     var menuBarIconOpacity: Double {
-        guard let q = worstQuota else { return 1.0 }
-        switch q.level {
-        case .critical: return 1.0
-        case .warning: return 0.7
-        case .good: return 1.0
-        }
+        guard !coloredMenuBar, let q = worstQuota else { return 1.0 }
+        return q.level == .warning ? 0.7 : 1.0
     }
 
-    var menuBarIconColor: Color {
-        guard let q = worstQuota else { return .primary }
-        switch q.level {
-        case .good: return .primary  // Use system color for contrast on light/dark menu bar
-        case .warning, .critical: return q.level.color
-        }
+    /// Usage-level tint applied to both the menu bar icon and its text, so the whole
+    /// label reads as one status indicator. `.primary` when tinting is off or no quota
+    /// has loaded yet — the system color keeps contrast on light and dark menu bars.
+    var menuBarTint: Color {
+        guard coloredMenuBar, let q = worstQuota else { return .primary }
+        return q.level.color
     }
 
     var nextResetDate: Date? {
@@ -862,6 +867,7 @@ class UsageManager: ObservableObject {
         self.windowHeight = savedHeight > 0 ? savedHeight : 650
         let savedDisplayMode = ud.integer(forKey: UDKey.menuBarDisplayMode)
         self.menuBarDisplayMode = MenuBarDisplayMode(rawValue: savedDisplayMode) ?? .percentageAndTimer
+        self.coloredMenuBar = ud.object(forKey: UDKey.coloredMenuBar) as? Bool ?? true
         self.dailyBudget = ud.double(forKey: UDKey.dailyBudget)
 
         // Load ring stat labels for Icon+ mode

--- a/docs/index.html
+++ b/docs/index.html
@@ -1581,7 +1581,7 @@
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--red)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
                 </div>
                 <h3>Rate limit alerts</h3>
-                <p>Menu bar icon turns green/orange/red based on usage. Get notified before hitting Claude rate limits.</p>
+                <p>Menu bar icon and text turn green/orange/red based on usage. Get notified before hitting Claude rate limits.</p>
             </div>
             <div class="feat">
                 <div class="feat-icon purple">


### PR DESCRIPTION
Fixes #44.

## What was wrong

`menuBarIconColor` returned `.primary` for the `.good` level (< 50%), so the green state the README advertises never rendered — at 15% the icon was plain white, exactly as reported.

Two things came out of digging into it:

1. **Green never existed.** Only `.warning` (≥ 50%) and `.critical` (≥ 80%) were tinted. The `.primary` fallback was a deliberate contrast choice, but it contradicted both the README and `docs/index.html`.
2. **The title text was never tinted, in any mode.** `Text(manager.menuBarTitle)` had no `foregroundStyle`, so even at 85% a red icon sat next to a plain white `85% · 2h31m`. Not specific to Timer mode — it affected Session, Timer, All and Session+Week alike.

## What changed

- `menuBarIconColor` → `menuBarTint`, which returns the worst quota's level color with no `.good` special case.
- The menu bar title now takes the same tint as the icon, so the whole label reads as one indicator.
- `menuBarIconOpacity` applies only when tinting is off. It existed to separate warning from critical in a monochrome menu bar; with color carrying that signal, 0.7 on orange only costs legibility.
- New **Color by usage level** toggle in Settings › Menu bar (`UDKey.coloredMenuBar`, default on). The contrast concern behind the original `.primary` is real on light menu bars, so monochrome stays available.
- README and landing page updated to say "icon **and text**", and the README notes the toggle.

## Testing

`xcodegen` isn't installed on the machine this was written on and the `.xcodeproj` is generated, so the checklist's `xcodebuild` step did not run. Type-checked instead:

```
xcrun swiftc -typecheck -target arm64-apple-macos13.0 -sdk "$(xcrun --sdk macosx --show-sdk-path)" Sources/*.swift
```

0 errors, 3 pre-existing unrelated warnings. **A real build plus a visual check of the tint against both light and dark menu bars is still needed before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)