### PR TITLE
fix: recover sessions the CLI no longer refreshes

### DIFF
--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -7,6 +7,14 @@ import Security
 
 // MARK: - Credential source
 
+/// A resolved Keychain item: the credentials payload plus the coordinates it
+/// was read from, so a refreshed token can be written back to that same item.
+struct KeychainCredentials {
+    let service: String
+    let account: String?
+    let json: [String: Any]
+}
+
 enum CredentialSource: String {
     case file = "credentials.json"
     case keychain = "Keychain"
@@ -28,11 +36,26 @@ class AuthManager: ObservableObject {
 
     private var credentialsWatcher: DispatchSourceFileSystemObject?
 
-    // OAuth refresh is intentionally NOT done by this app. Claude Code owns
-    // the single-use refresh-token cycle; if we consume the token, the CLI's
-    // in-memory copy becomes stale and the user is forced to /login again on
-    // the next `claude` invocation. See issue #40 and the note further down
-    // where `selfRefreshToken` used to live.
+    /// The Keychain item credentials were last read from. Refreshed tokens are
+    /// written back to this exact (service, account) pair instead of a guessed
+    /// one, so we never shadow Claude Code's entry with a duplicate the app
+    /// would then read instead of the real thing.
+    private var keychainEntry: KeychainCredentials?
+    private var isSelfRefreshing = false
+    private var lastSelfRefreshFailure: Date?
+    /// Callers that asked for a refresh while one was already in flight — they all
+    /// get the same outcome instead of racing a second grant on the same token.
+    private var selfRefreshWaiters: [(Bool) -> Void] = []
+
+    // Refreshing OAuth tokens is Claude Code's job, not ours: the refresh token
+    // is single-use and shared with the CLI, so spending it while the CLI still
+    // holds the matching copy in memory forces the user to /login (issue #40).
+    // The single exception is a token that has been dead for `staleTokenGrace`
+    // — Claude Code rotates credentials on any use, so an entry that stale means
+    // no CLI is alive to be broken. Without that exception the app is bricked
+    // for anyone who stopped running `claude` in a terminal (the desktop app
+    // keeps its own auth and never touches this Keychain entry).
+    // `recoverSession` is the only entry point; see it below.
 
     static let credentialsPath: URL = {
         FileManager.default.homeDirectoryForCurrentUser
@@ -93,13 +116,16 @@ class AuthManager: ObservableObject {
 
         // Keychain — read off the main thread to avoid blocking UI.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let keychainJSON = Self.loadFromKeychain()
+            let keychainEntry = Self.loadFromKeychain()
             DispatchQueue.main.async {
                 guard let self else { return }
+                // Remember where the Keychain copy lives even when the file wins
+                // below — that item is still the one a refresh must write back to.
+                if let keychainEntry { self.keychainEntry = keychainEntry }
 
                 // Both sources may be stale; take whichever token lives longest.
                 let candidates: [([String: Any], CredentialSource)] = [
-                    keychainJSON.map { ($0, CredentialSource.keychain) },
+                    keychainEntry.map { ($0.json, CredentialSource.keychain) },
                     fileJSON.map { ($0, CredentialSource.file) }
                 ].compactMap { $0 }
 
@@ -149,12 +175,215 @@ class AuthManager: ObservableObject {
         resolveCredentials(completion: completion)
     }
 
-    // NOTE: There is no silent OAuth `refresh_token` grant in this app on purpose.
-    // Claude Code's refresh token is single-use and shared with the CLI: if we
-    // spent it, the CLI's in-memory token would 401 and force `/login` again
-    // (see issue #40). When our token expires we reload from disk/Keychain in
-    // case Claude Code has since refreshed it, and otherwise ask the user to
-    // run `claude auth login`.
+    // MARK: - Session recovery
+
+    private static let oauthTokenURL = URL(string: "https://platform.claude.com/v1/oauth/token")!
+    private static let oauthClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    /// How long the stored access token must have been expired before this app may
+    /// spend the shared refresh token. Claude Code rotates credentials on any use,
+    /// so an entry dead this long belongs to no running CLI (issue #40).
+    private static let staleTokenGrace: TimeInterval = 12 * 3600
+
+    /// Cool-down after a failed self-refresh, so a broken refresh token is not
+    /// retried on every poll tick.
+    private static let selfRefreshRetryDelay: TimeInterval = 5 * 60
+
+    /// Whether silent recovery is on the table: a refresh token exists, the access
+    /// token has been dead longer than `staleTokenGrace`, and the last failure is
+    /// old enough to retry. Stays true while an attempt is in flight — callers use
+    /// this to decide whether to wait rather than prompt the user to sign in.
+    var canSelfRefresh: Bool {
+        if isSelfRefreshing { return true }
+        guard let refreshToken, !refreshToken.isEmpty,
+              let expiresAt = tokenExpiresAt else { return false }
+        let deadFor = Date().timeIntervalSince(Date(timeIntervalSince1970: expiresAt / 1000))
+        guard deadFor >= Self.staleTokenGrace else { return false }
+        guard let lastFailure = lastSelfRefreshFailure else { return true }
+        return Date().timeIntervalSince(lastFailure) >= Self.selfRefreshRetryDelay
+    }
+
+    /// Bring the session back online without user interaction when possible.
+    ///
+    /// Reloads from disk/Keychain first — Claude Code may have refreshed since we
+    /// last looked, and adopting its token costs nothing. Only if that still leaves
+    /// a long-dead token do we spend the refresh token ourselves. Completion
+    /// reports whether a usable (non-expired) token is now loaded.
+    func recoverSession(completion: @escaping (Bool) -> Void) {
+        reloadCredentials { [weak self] _ in
+            guard let self else { completion(false); return }
+            if self.isAuthenticated && !self.tokenExpired {
+                completion(true)
+                return
+            }
+            guard self.canSelfRefresh else {
+                completion(false)
+                return
+            }
+            Log.info("Token dead for >\(Int(Self.staleTokenGrace / 3600))h — no live CLI can hold it, refreshing ourselves")
+            self.selfRefreshToken(completion: completion)
+        }
+    }
+
+    /// Silent OAuth `refresh_token` grant. Private on purpose: `recoverSession`
+    /// owns the staleness gate that keeps this off an active CLI's tokens.
+    /// New tokens are written back to the Keychain (and credentials file when it
+    /// exists) so Claude Code picks them up on its next run.
+    private func selfRefreshToken(completion: @escaping (Bool) -> Void) {
+        guard let rt = refreshToken, !rt.isEmpty else {
+            Log.warn("selfRefreshToken: no refresh token available")
+            completion(false)
+            return
+        }
+
+        // Coalesce: a second caller joins the in-flight grant instead of spending
+        // the (now rotated) refresh token a second time.
+        if isSelfRefreshing {
+            Log.info("selfRefreshToken: grant already in flight, waiting for it")
+            selfRefreshWaiters.append(completion)
+            return
+        }
+
+        isSelfRefreshing = true
+        Log.info("selfRefreshToken: attempting refresh_token grant")
+
+        let finish: (Bool) -> Void = { [weak self] success in
+            DispatchQueue.main.async {
+                guard let self else { completion(success); return }
+                self.isSelfRefreshing = false
+                self.lastSelfRefreshFailure = success ? nil : Date()
+                let waiters = self.selfRefreshWaiters
+                self.selfRefreshWaiters = []
+                completion(success)
+                waiters.forEach { $0(success) }
+            }
+        }
+
+        var request = URLRequest(url: Self.oauthTokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("claude-code/2.1", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 15
+        // RFC 6749 §6 requires form-encoded bodies for token endpoint requests.
+        var allowedChars = CharacterSet.alphanumerics
+        allowedChars.insert(charactersIn: "-._~")
+        let encodedToken = rt.addingPercentEncoding(withAllowedCharacters: allowedChars) ?? rt
+        request.httpBody = "grant_type=refresh_token&refresh_token=\(encodedToken)&client_id=\(Self.oauthClientID)"
+            .data(using: .utf8)
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
+            guard let self else { finish(false); return }
+
+            if let error {
+                Log.error("selfRefreshToken: network error: \(error.localizedDescription)")
+                finish(false)
+                return
+            }
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let newAccessToken = json["access_token"] as? String, !newAccessToken.isEmpty else {
+                let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? "(no body)"
+                Log.error("selfRefreshToken: bad response — \(body.prefix(200))")
+                finish(false)
+                return
+            }
+
+            let newRefreshToken = json["refresh_token"] as? String ?? rt
+            let expiresIn = json["expires_in"] as? Double ?? 3600
+            let newExpiresAt = (Date().timeIntervalSince1970 + expiresIn) * 1000
+
+            DispatchQueue.main.async {
+                self.accessToken = newAccessToken
+                self.refreshToken = newRefreshToken
+                self.tokenExpiresAt = newExpiresAt
+                self.isAuthenticated = true
+                Log.info("selfRefreshToken: success — new token expires in \(Int(expiresIn))s")
+                self.persistRefreshedCredentials(
+                    accessToken: newAccessToken,
+                    refreshToken: newRefreshToken,
+                    expiresAt: newExpiresAt
+                )
+                finish(true)
+            }
+        }.resume()
+    }
+
+    /// Write refreshed tokens back to the Keychain item they came from and to the
+    /// credentials file when present, preserving every other field
+    /// (subscriptionType, rateLimitTier, scopes) so Claude Code picks up the
+    /// rotation instead of 401-ing on a token we spent.
+    ///
+    /// The write goes through `SecItemUpdate` rather than
+    /// `security add-generic-password -U`: Claude Code's item carries no account
+    /// attribute, which the CLI cannot express (`-a` is mandatory), so the CLI
+    /// would happily *create* a second item that then shadows the real one on
+    /// every read. `SecItemUpdate` either updates the item we read or fails.
+    private func persistRefreshedCredentials(accessToken: String, refreshToken: String, expiresAt: Double) {
+        guard let entry = keychainEntry else {
+            Log.warn("persistRefreshedCredentials: no Keychain item on record, updating file only")
+            Self.updateCredentialsFile(accessToken: accessToken, refreshToken: refreshToken, expiresAt: expiresAt)
+            return
+        }
+
+        DispatchQueue.global(qos: .utility).async {
+            var root = entry.json
+            var oauth = root["claudeAiOauth"] as? [String: Any] ?? [:]
+            oauth["accessToken"] = accessToken
+            oauth["refreshToken"] = refreshToken
+            oauth["expiresAt"] = Int(expiresAt)
+            root["claudeAiOauth"] = oauth
+
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: root) else {
+                Log.error("persistRefreshedCredentials: failed to serialize JSON")
+                return
+            }
+
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: entry.service
+            ]
+            // Absent account attribute → match the item however it stores it,
+            // rather than inventing an empty-string account of our own.
+            if let account = entry.account { query[kSecAttrAccount as String] = account }
+
+            let status = SecItemUpdate(query as CFDictionary, [kSecValueData as String: jsonData] as CFDictionary)
+            if status == errSecSuccess {
+                Log.info("persistRefreshedCredentials: Keychain item \(entry.service) updated")
+            } else {
+                // Not fatal for us — the fresh token lives in memory — but Claude Code
+                // will still hold the spent one, so say so loudly.
+                Log.error("persistRefreshedCredentials: SecItemUpdate failed (status \(status)) — Claude Code keeps the old token")
+            }
+
+            Self.updateCredentialsFile(accessToken: accessToken, refreshToken: refreshToken, expiresAt: expiresAt)
+        }
+    }
+
+    /// Mirror refreshed tokens into `~/.claude/.credentials.json` when that file is
+    /// the store this machine uses. No-op when it does not exist.
+    private static func updateCredentialsFile(accessToken: String, refreshToken: String, expiresAt: Double) {
+        guard FileManager.default.fileExists(atPath: credentialsPath.path),
+              let fileData = try? Data(contentsOf: credentialsPath),
+              var fileJSON = try? JSONSerialization.jsonObject(with: fileData) as? [String: Any]
+        else { return }
+
+        var oauth = fileJSON["claudeAiOauth"] as? [String: Any] ?? [:]
+        oauth["accessToken"] = accessToken
+        oauth["refreshToken"] = refreshToken
+        oauth["expiresAt"] = Int(expiresAt)
+        fileJSON["claudeAiOauth"] = oauth
+
+        guard let newData = try? JSONSerialization.data(withJSONObject: fileJSON) else {
+            Log.error("updateCredentialsFile: failed to serialize JSON")
+            return
+        }
+        do {
+            try newData.write(to: credentialsPath)
+            Log.info("updateCredentialsFile: credentials file updated")
+        } catch {
+            Log.error("updateCredentialsFile: write failed: \(error.localizedDescription)")
+        }
+    }
 
     // MARK: - Credentials file watcher
 
@@ -212,20 +441,22 @@ class AuthManager: ObservableObject {
     ///   2. `security find-generic-password -s "Claude Code-credentials" -a $USER`
     ///   3. `SecItemCopyMatching` scan over all `Claude Code-credentials*` entries
     ///      (covers per-project suffixed entries from newer Claude Code versions)
-    static func loadFromKeychain() -> [String: Any]? {
-        if let json = readKeychainViaSecurityCLI(service: "Claude Code-credentials", account: nil),
+    static func loadFromKeychain() -> KeychainCredentials? {
+        let service = "Claude Code-credentials"
+
+        if let json = readKeychainViaSecurityCLI(service: service, account: nil),
            hasFreshOAuthToken(json) {
-            return json
+            return KeychainCredentials(service: service, account: nil, json: json)
         }
 
         let user = NSUserName()
         if !user.isEmpty,
-           let json = readKeychainViaSecurityCLI(service: "Claude Code-credentials", account: user),
+           let json = readKeychainViaSecurityCLI(service: service, account: user),
            hasFreshOAuthToken(json) {
-            return json
+            return KeychainCredentials(service: service, account: user, json: json)
         }
 
-        return loadBestKeychainEntryWithPrefix("Claude Code-credentials")
+        return loadBestKeychainEntryWithPrefix(service)
     }
 
     private static func readKeychainViaSecurityCLI(service: String, account: String?) -> [String: Any]? {
@@ -263,7 +494,7 @@ class AuthManager: ObservableObject {
         return Date(timeIntervalSince1970: expiresAt / 1000) > Date()
     }
 
-    private static func loadBestKeychainEntryWithPrefix(_ prefix: String) -> [String: Any]? {
+    private static func loadBestKeychainEntryWithPrefix(_ prefix: String) -> KeychainCredentials? {
         // The legacy file-based login keychain rejects kSecReturnAttributes+kSecReturnData
         // together with kSecMatchLimitAll (returns errSecParam). Enumerate refs+attributes
         // first, then fetch each item's data with a per-item query.
@@ -281,9 +512,8 @@ class AuthManager: ObservableObject {
             return nil
         }
 
-        var bestJSON: [String: Any]?
+        var best: KeychainCredentials?
         var bestExpiry: Double = 0
-        var bestAccount: String = ""
 
         for item in items {
             guard let service = item[kSecAttrService as String] as? String,
@@ -299,14 +529,13 @@ class AuthManager: ObservableObject {
             let expiresAt = oauth["expiresAt"] as? Double ?? 0
             if expiresAt > bestExpiry {
                 bestExpiry = expiresAt
-                bestJSON = json
-                bestAccount = account
+                best = KeychainCredentials(service: service, account: account.isEmpty ? nil : account, json: json)
             }
         }
 
-        if bestJSON != nil {
-            Log.info("loadBestKeychainEntryWithPrefix: using entry account=\(bestAccount.isEmpty ? "<empty>" : bestAccount) (prefix: \(prefix))")
+        if let best {
+            Log.info("loadBestKeychainEntryWithPrefix: using entry account=\(best.account ?? "<empty>") (prefix: \(prefix))")
         }
-        return bestJSON
+        return best
     }
 }

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -809,6 +809,8 @@ class UsageManager: ObservableObject {
     // MARK: - Constants
 
     private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
+    /// Budget for a session recovery round-trip (Keychain read + possible token refresh).
+    private static let sessionRecoveryTimeout: TimeInterval = 20
     private static let maxRetries = 5
     private static let retryBaseDelay: Double = 5
     private static let rateLimitRetryBaseDelay: Double = 5
@@ -947,7 +949,10 @@ class UsageManager: ObservableObject {
                 guard let self else { return }
                 // tokenExpired guard prevents a flicker loop: fetchUsage -> reloadCredentials -> auth republishes -> sink fires again.
                 if self.auth.tokenExpired {
-                    if self.autoReconnect && !self.isAutoReconnecting && !self.reconnectExhausted {
+                    // Give the silent path first refusal: popping a sign-in terminal
+                    // for a session the poller can restore on its own is pure noise.
+                    if self.autoReconnect && !self.isAutoReconnecting && !self.reconnectExhausted
+                        && !self.auth.canSelfRefresh {
                         self.launchAutoReconnect()
                     }
                     // Poll credentials in the background so a manual `claude auth login`
@@ -1336,9 +1341,18 @@ class UsageManager: ObservableObject {
                     self.expiredCredentialTimer = nil
                     return
                 }
-                self.auth.reloadCredentials { [weak self] _ in
-                    guard let self, !self.auth.tokenExpired else { return }
-                    Log.info("Expired credential poller: fresh credentials detected, resuming")
+                self.auth.recoverSession { [weak self] recovered in
+                    guard let self else { return }
+                    guard recovered, !self.auth.tokenExpired else {
+                        // Silent recovery is out of options — fall back to asking
+                        // the user to sign in, if they opted into auto-reconnect.
+                        if self.autoReconnect && !self.isAutoReconnecting
+                            && !self.reconnectExhausted && !self.auth.canSelfRefresh {
+                            self.launchAutoReconnect()
+                        }
+                        return
+                    }
+                    Log.info("Expired credential poller: session recovered, resuming")
                     self.expiredCredentialTimer?.cancel()
                     self.expiredCredentialTimer = nil
                     self.reconnectExhausted = false
@@ -1410,9 +1424,10 @@ class UsageManager: ObservableObject {
     }
 
     private func refreshInternal() {
-        // Safety: if isLoading has been stuck for >20s, cancel in-flight fetch and reset
-        if isLoading, let started = loadingStartedAt, Date().timeIntervalSince(started) > 20 {
-            Log.warn("isLoading stuck for >20s — cancelling fetch and resetting")
+        // Safety: if isLoading has been stuck for >30s, cancel in-flight fetch and reset.
+        // Must stay above sessionRecoveryTimeout so a legitimate recovery isn't killed.
+        if isLoading, let started = loadingStartedAt, Date().timeIntervalSince(started) > 30 {
+            Log.warn("isLoading stuck for >30s — cancelling fetch and resetting")
             currentFetchTask?.cancel()
             finishLoading()
         }
@@ -1422,12 +1437,12 @@ class UsageManager: ObservableObject {
             return
         }
 
-        // Never proactively refresh the OAuth token ourselves — the refresh
-        // token is single-use and shared with the Claude Code CLI, so consuming
-        // it here invalidates the CLI's in-memory token and forces the user to
-        // /login again (see issue #40). If the token is stale we reload from
-        // disk/Keychain in case Claude Code has since refreshed it; otherwise
-        // fetchUsage will surface "Session expired — run `claude auth login`".
+        // Never *proactively* refresh the OAuth token — it is single-use and shared
+        // with the Claude Code CLI, so consuming it early invalidates the CLI's
+        // in-memory copy and forces the user to /login (see issue #40). Recovery is
+        // reactive only: fetchUsage calls auth.recoverSession, which reloads from
+        // disk/Keychain and refreshes solely when the token has been dead so long
+        // that no CLI can still be holding it.
         isLoading = true
         loadingStartedAt = Date()
         errorMessage = nil
@@ -1443,16 +1458,16 @@ class UsageManager: ObservableObject {
         }
 
         if auth.tokenExpired {
-            Log.warn("Token expired, attempting to reload credentials...")
+            Log.warn("Token expired, attempting to recover the session...")
             var didComplete = false
             let timeout = DispatchWorkItem { [weak self] in
                 guard let self, !didComplete else { return }
                 didComplete = true
-                Log.warn("Credential reload timed out after 10s")
+                Log.warn("Session recovery timed out after \(Int(Self.sessionRecoveryTimeout))s")
                 self.finishLoading(error: "Session expired — run `claude auth login`")
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10, execute: timeout)
-            auth.reloadCredentials { [weak self] success in
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.sessionRecoveryTimeout, execute: timeout)
+            auth.recoverSession { [weak self] success in
                 timeout.cancel()
                 guard let self, !didComplete else { return }
                 didComplete = true
@@ -1546,9 +1561,9 @@ class UsageManager: ObservableObject {
                     self.updateWidgetData()
 
                 case 401, 403:
-                    if self.auth.refreshToken != nil && retryCount == 0 {
-                        Log.info("Got \(httpResponse.statusCode), attempting token refresh...")
-                        self.auth.reloadCredentials { [weak self] success in
+                    if retryCount == 0 {
+                        Log.info("Got \(httpResponse.statusCode), attempting session recovery...")
+                        self.auth.recoverSession { [weak self] success in
                             guard let self else { return }
                             if success {
                                 self.fetchUsage(retryCount: retryCount + 1)
@@ -1563,41 +1578,52 @@ class UsageManager: ObservableObject {
                 case 429:
                     let retryAfterHeader = httpResponse.value(forHTTPHeaderField: "Retry-After")
                     let retryAfterValue = retryAfterHeader.flatMap(Double.init) ?? -1
-                    self.consecutive429Count += 1
 
-                    // Retry-After:0 likely means stale token — try refreshing once
-                    if retryAfterValue <= 0 && self.auth.refreshToken != nil && retryCount == 0 {
-                        Log.info("429 with Retry-After:\(Int(retryAfterValue)) — likely stale token, refreshing...")
-                        self.auth.reloadCredentials { [weak self] success in
+                    // A 429 on a token we already know is expired — or one answered
+                    // with Retry-After: 0 — is an authentication artifact, not a quota
+                    // limit. Recover the session instead of starting a cooldown and
+                    // telling the user to wait for a limit that was never hit.
+                    let looksLikeStaleToken = self.auth.tokenExpired || retryAfterValue <= 0
+                    if looksLikeStaleToken && retryCount == 0 {
+                        Log.info("429 (Retry-After:\(Int(retryAfterValue)), expired:\(self.auth.tokenExpired)) — recovering session...")
+                        self.auth.recoverSession { [weak self] success in
                             guard let self else { return }
                             if success {
-                                Log.info("Token refreshed, retrying fetch...")
+                                Log.info("Session recovered, retrying fetch...")
                                 self.fetchUsage(retryCount: retryCount + 1)
                             } else {
                                 self.finishLoading(error: "Session expired — run `claude auth login`")
                             }
                         }
+                        return
+                    }
+
+                    // Recovery already ran and the token is still dead: report the real
+                    // problem rather than an imaginary rate limit.
+                    if self.auth.tokenExpired {
+                        self.finishLoading(error: "Session expired — run `claude auth login`")
+                        return
+                    }
+
+                    self.consecutive429Count += 1
+                    // Server provided a real Retry-After: respect it (capped at 2h)
+                    let cooldown: Double
+                    if retryAfterValue > 0 {
+                        cooldown = min(retryAfterValue, 7200)
                     } else {
-                        // Server provided a real Retry-After: respect it (capped at 2h)
-                        // No Retry-After or zero after token refresh failed: short cooldown
-                        let cooldown: Double
-                        if retryAfterValue > 0 {
-                            cooldown = min(retryAfterValue, 7200)
-                        } else {
-                            // No Retry-After header — use moderate backoff
-                            let steps: [Double] = [15, 30, 60, 120, 300, 600]
-                            let index = min(self.consecutive429Count - 1, steps.count - 1)
-                            cooldown = steps[index]
-                        }
-                        self.rateLimitedUntil = Date().addingTimeInterval(cooldown)
-                        if !self.quotas.isEmpty {
-                            self.finishLoading()
-                            Log.info("Rate limited (429), keeping existing data, retry in \(Int(cooldown))s")
-                        } else {
-                            let display = cooldown >= 60 ? "\(Int(cooldown / 60))min" : "\(Int(cooldown))s"
-                            self.finishLoading(error: "Rate limited — retrying in \(display)")
-                            Log.info("Rate limited (429 #\(self.consecutive429Count)), no data yet, will auto-retry in \(Int(cooldown))s")
-                        }
+                        // No Retry-After header — use moderate backoff
+                        let steps: [Double] = [15, 30, 60, 120, 300, 600]
+                        let index = min(self.consecutive429Count - 1, steps.count - 1)
+                        cooldown = steps[index]
+                    }
+                    self.rateLimitedUntil = Date().addingTimeInterval(cooldown)
+                    if !self.quotas.isEmpty {
+                        self.finishLoading()
+                        Log.info("Rate limited (429), keeping existing data, retry in \(Int(cooldown))s")
+                    } else {
+                        let display = cooldown >= 60 ? "\(Int(cooldown / 60))min" : "\(Int(cooldown))s"
+                        self.finishLoading(error: "Rate limited — retrying in \(display)")
+                        Log.info("Rate limited (429 #\(self.consecutive429Count)), no data yet, will auto-retry in \(Int(cooldown))s")
                     }
 
                 default:


### PR DESCRIPTION
## Problème

Depuis la v2.25.1, l'app ne rafraîchit plus jamais le token OAuth elle-même : elle compte sur Claude Code pour réécrire l'entrée Keychain `Claude Code-credentials`. Cette hypothèse tombe dès qu'on arrête de lancer `claude` dans un terminal — l'app desktop gère sa propre auth et ne touche jamais cette entrée. Le token expire, plus rien ne le renouvelle, et l'app est morte définitivement.

Constaté sur une machine dont l'entrée n'avait pas bougé depuis trois semaines : l'API répondait `401 — OAuth access token has expired`, pendant que l'UI affichait « Rate limited — retrying in 30s ».

## Correctifs

**1. `recoverSession()` — récupération silencieuse sous garde-fou de fraîcheur**

- recharge d'abord disque/Keychain (Claude Code a peut-être rafraîchi entre-temps — gratuit) ;
- ne dépense le refresh token partagé que si le token d'accès est mort depuis **12 h**.

Claude Code fait tourner ses credentials à chaque utilisation : une entrée morte depuis 12 h n'appartient à aucun CLI vivant. C'est précisément ce que visait #40 — l'ancien code rafraîchissait *proactivement* toutes les 30 min et écrasait des tokens que le CLI gardait en mémoire. Ici la récupération est purement réactive, `selfRefreshToken` est privé (seul `recoverSession` y accède), les appels concurrents sont coalescés, et un échec impose 5 min de backoff.

**2. Écriture Keychain via `SecItemUpdate`**

L'entrée de Claude Code n'a pas d'attribut compte, ce que le CLI `security` ne sait pas exprimer (`-a` est obligatoire) : l'ancienne implémentation aurait créé une **seconde entrée** masquant la vraie à chaque lecture. Vérifié sur une entrée jetable sans compte : `SecItemUpdate` met à jour en place, 1 seule entrée, zéro doublon.

**3. Plus de faux rate limit**

Un 429 sur un token qu'on sait expiré est un artefact d'authentification. Il déclenche désormais une récupération de session, et si le token reste mort → « Session expired » + bouton Sign In, au lieu d'envoyer l'utilisateur attendre une limite jamais atteinte. Le vrai rate limit (`Retry-After` réel, token valide) garde son comportement d'origine.

## Vérification

- `swiftc -typecheck` sur tout `Sources/` (target macOS 13) : 0 erreur, seuls les 3 warnings préexistants.
- ⚠️ **`xcodebuild` n'a pas pu être lancé** : pas d'Xcode sur la machine de dev (`xcode-select` pointe sur les Command Line Tools). À refaire avant la release.
- Non testé : le prompt d'accès Keychain inter-app quand l'app modifie l'entrée créée par Claude Code. En cas d'échec, c'est loggé explicitement (`SecItemUpdate failed … Claude Code keeps the old token`) et le fichier de credentials est mis à jour malgré tout.

Release (CHANGELOG + bump de version) à faire après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)