### PR TITLE
fix: make multi-account switching actually switch accounts

### DIFF
--- a/Sources/ActiveAccount.swift
+++ b/Sources/ActiveAccount.swift
@@ -1,0 +1,40 @@
+// ActiveAccount.swift
+// Where the currently selected account keeps its data.
+//
+// Claude Code namespaces everything by config directory: with CLAUDE_CONFIG_DIR
+// unset it uses ~/.claude and the Keychain service "Claude Code-credentials";
+// with CLAUDE_CONFIG_DIR=D it uses D and the service
+// "Claude Code-credentials-<h>", where <h> is the first 8 hex characters of
+// sha256(D). Pointing this store at an account's config dir is what makes
+// credential loading, session analytics and the file watcher all follow the
+// account the user picked in the popover instead of whichever token happens
+// to be freshest.
+
+import Foundation
+import CryptoKit
+
+enum ActiveAccount {
+    /// Config dir of the active account; nil = the default ~/.claude login.
+    /// Only mutated on the main thread (startup and switchAccount).
+    static var configDir: String?
+
+    /// The directory holding this account's data (projects/, .credentials.json).
+    static var dataDir: URL {
+        configDir.map { URL(fileURLWithPath: $0) }
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude")
+    }
+
+    static var credentialsFile: URL { dataDir.appendingPathComponent(".credentials.json") }
+
+    static var keychainService: String {
+        guard let dir = configDir else { return "Claude Code-credentials" }
+        let hash = SHA256.hash(data: Data(dir.utf8))
+            .map { String(format: "%02x", $0) }.joined().prefix(8)
+        return "Claude Code-credentials-\(hash)"
+    }
+
+    /// Whether an explicit non-default account is selected. When true the
+    /// Keychain lookup must match this exact service — the freshest-token
+    /// prefix scan would bleed one account's credentials into another's view.
+    static var isPinned: Bool { configDir != nil }
+}

--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -57,10 +57,7 @@ class AuthManager: ObservableObject {
     // keeps its own auth and never touches this Keychain entry).
     // `recoverSession` is the only entry point; see it below.
 
-    static let credentialsPath: URL = {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/.credentials.json")
-    }()
+    static var credentialsPath: URL { ActiveAccount.credentialsFile }
 
     // MARK: - Credential loading
 
@@ -68,7 +65,7 @@ class AuthManager: ObservableObject {
         resolveCredentials { _ in }
     }
 
-    /// Credentials JSON from `~/.claude/.credentials.json`, or nil if absent/unusable.
+    /// Credentials JSON from the active account's `.credentials.json`, or nil if absent/unusable.
     private static func fileCredentialsJSON() -> [String: Any]? {
         guard let data = try? Data(contentsOf: credentialsPath),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -138,7 +135,8 @@ class AuthManager: ObservableObject {
                     return
                 }
 
-                if let envToken = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"],
+                if !ActiveAccount.isPinned,
+                   let envToken = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"],
                    !envToken.isEmpty {
                     self.accessToken = envToken
                     self.credentialSource = .environment
@@ -437,12 +435,15 @@ class AuthManager: ObservableObject {
     /// `$USER`, so the per-account fast path resolves cleanly without any prompt.
     ///
     /// Order:
-    ///   1. `security find-generic-password -s "Claude Code-credentials"` (no `-a`)
-    ///   2. `security find-generic-password -s "Claude Code-credentials" -a $USER`
-    ///   3. `SecItemCopyMatching` scan over all `Claude Code-credentials*` entries
-    ///      (covers per-project suffixed entries from newer Claude Code versions)
+    ///   1. `security find-generic-password -s <active account's service>` (no `-a`)
+    ///   2. `security find-generic-password -s <active account's service> -a $USER`
+    ///   3. `SecItemCopyMatching` scan — prefix-matched when no explicit account
+    ///      is selected (covers per-project suffixed entries from newer Claude
+    ///      Code versions), but exact-matched for a pinned account: the
+    ///      freshest-token prefix scan would otherwise resolve to whichever
+    ///      *other* account refreshed most recently.
     static func loadFromKeychain() -> KeychainCredentials? {
-        let service = "Claude Code-credentials"
+        let service = ActiveAccount.keychainService
 
         if let json = readKeychainViaSecurityCLI(service: service, account: nil),
            hasFreshOAuthToken(json) {
@@ -456,7 +457,7 @@ class AuthManager: ObservableObject {
             return KeychainCredentials(service: service, account: user, json: json)
         }
 
-        return loadBestKeychainEntryWithPrefix(service)
+        return loadBestKeychainEntry(matching: service, exact: ActiveAccount.isPinned)
     }
 
     private static func readKeychainViaSecurityCLI(service: String, account: String?) -> [String: Any]? {
@@ -494,7 +495,7 @@ class AuthManager: ObservableObject {
         return Date(timeIntervalSince1970: expiresAt / 1000) > Date()
     }
 
-    private static func loadBestKeychainEntryWithPrefix(_ prefix: String) -> KeychainCredentials? {
+    private static func loadBestKeychainEntry(matching target: String, exact: Bool) -> KeychainCredentials? {
         // The legacy file-based login keychain rejects kSecReturnAttributes+kSecReturnData
         // together with kSecMatchLimitAll (returns errSecParam). Enumerate refs+attributes
         // first, then fetch each item's data with a per-item query.
@@ -508,7 +509,7 @@ class AuthManager: ObservableObject {
         let listStatus = SecItemCopyMatching(listQuery as CFDictionary, &listRaw)
         guard listStatus == errSecSuccess,
               let items = listRaw as? [[String: Any]] else {
-            Log.info("loadBestKeychainEntryWithPrefix: list query failed status=\(listStatus)")
+            Log.info("loadBestKeychainEntry: list query failed status=\(listStatus)")
             return nil
         }
 
@@ -517,7 +518,7 @@ class AuthManager: ObservableObject {
 
         for item in items {
             guard let service = item[kSecAttrService as String] as? String,
-                  service.hasPrefix(prefix) else { continue }
+                  exact ? service == target : service.hasPrefix(target) else { continue }
             let account = item[kSecAttrAccount as String] as? String ?? ""
 
             // ponytail: use CLI (no-prompt) instead of SecItemCopyMatching+kSecReturnData (prompts)
@@ -534,7 +535,7 @@ class AuthManager: ObservableObject {
         }
 
         if let best {
-            Log.info("loadBestKeychainEntryWithPrefix: using entry account=\(best.account ?? "<empty>") (prefix: \(prefix))")
+            Log.info("loadBestKeychainEntry: using entry service=\(best.service) account=\(best.account ?? "<empty>") (target: \(target), exact: \(exact))")
         }
         return best
     }

--- a/Sources/AuthManager.swift
+++ b/Sources/AuthManager.swift
@@ -41,6 +41,12 @@ class AuthManager: ObservableObject {
     /// one, so we never shadow Claude Code's entry with a duplicate the app
     /// would then read instead of the real thing.
     private var keychainEntry: KeychainCredentials?
+
+    /// Bumped on every account switch. A Keychain read runs off the main thread,
+    /// so a resolution started for the previous account can land after the user
+    /// has already picked another one — the generation it captured no longer
+    /// matches and its result is dropped instead of adopted.
+    private var accountGeneration = 0
     private var isSelfRefreshing = false
     private var lastSelfRefreshFailure: Date?
     /// Callers that asked for a refresh while one was already in flight — they all
@@ -58,6 +64,25 @@ class AuthManager: ObservableObject {
     // `recoverSession` is the only entry point; see it below.
 
     static var credentialsPath: URL { ActiveAccount.credentialsFile }
+
+    /// Forget the current account's credentials before another one is loaded.
+    ///
+    /// `resolveCredentials` deliberately keeps the last good token when a read
+    /// comes back empty, so a transient failure never signs the user out. On a
+    /// deliberate account switch that guarantee is exactly backwards: the
+    /// popover would keep serving the previous account's quota under the newly
+    /// selected row. Clearing `keychainEntry` matters just as much — a refresh
+    /// must not write the new account's token into the old account's item.
+    func resetForAccountSwitch() {
+        accountGeneration += 1
+        accessToken = nil
+        refreshToken = nil
+        tokenExpiresAt = nil
+        keychainEntry = nil
+        subscriptionType = ""
+        credentialSource = .none
+        isAuthenticated = false
+    }
 
     // MARK: - Credential loading
 
@@ -102,6 +127,7 @@ class AuthManager: ObservableObject {
     /// an expired token, so re-signing in never cleared "Session expired".
     private func resolveCredentials(completion: @escaping (Bool) -> Void) {
         let previousToken = accessToken
+        let generation = accountGeneration
         let fileJSON = Self.fileCredentialsJSON()
 
         // Fast path: file token still valid — no Keychain round-trip needed.
@@ -116,6 +142,12 @@ class AuthManager: ObservableObject {
             let keychainEntry = Self.loadFromKeychain()
             DispatchQueue.main.async {
                 guard let self else { return }
+                guard generation == self.accountGeneration else {
+                    // The active account changed while this read was in flight;
+                    // whatever it found belongs to the account we just left.
+                    completion(false)
+                    return
+                }
                 // Remember where the Keychain copy lives even when the file wins
                 // below — that item is still the one a refresh must write back to.
                 if let keychainEntry { self.keychainEntry = keychainEntry }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -679,12 +679,21 @@ struct MenuBarView: View {
                         SHLabel("Accounts")
                         Spacer()
                         SHButton(label: "Add", icon: "plus", style: .ghost) {
-                            let label = manager.accounts.isEmpty ? "Default" : "Account \(manager.accounts.count + 1)"
-                            manager.addAccount(label: label, path: AuthManager.credentialsPath.path)
+                            let panel = NSOpenPanel()
+                            panel.canChooseFiles = false
+                            panel.canChooseDirectories = true
+                            panel.allowsMultipleSelection = false
+                            panel.showsHiddenFiles = true
+                            panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+                            panel.message = "Choose the account's config directory — the folder its CLAUDE_CONFIG_DIR points to"
+                            panel.prompt = "Add Account"
+                            if panel.runModal() == .OK, let url = panel.url {
+                                manager.addAccount(configDirURL: url)
+                            }
                         }
                     }
                     if manager.accounts.isEmpty {
-                        Text("Using default credentials. Add accounts to switch between profiles.")
+                        Text("Using default credentials. Add an account's config directory (CLAUDE_CONFIG_DIR) to switch between logins.")
                             .shFont(11)
                             .foregroundColor(.secondary)
                     } else {
@@ -695,6 +704,9 @@ struct MenuBarView: View {
                                     .frame(width: 6, height: 6)
                                 Text(account.label)
                                     .shFont(11, weight: index == manager.activeAccountIndex ? .semibold : .regular)
+                                Text(account.configDir == nil ? "default" : "profile")
+                                    .shFont(9)
+                                    .foregroundColor(.secondary)
                                 Spacer()
                                 if index != manager.activeAccountIndex {
                                     SHButton(label: "Switch", style: .ghost) {

--- a/Sources/SessionAnalyzer.swift
+++ b/Sources/SessionAnalyzer.swift
@@ -408,10 +408,9 @@ class SessionAnalyzer {
         JSONDecoder()
     }()
 
-    static let projectsDir: URL = {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
-    }()
+    // Computed so switching accounts re-points every consumer at the active
+    // account's transcripts.
+    static var projectsDir: URL { ActiveAccount.dataDir.appendingPathComponent("projects") }
 
     /// Max JSONL file size to load into memory (300 MB)
     private static let maxFileSize: UInt64 = 300 * 1024 * 1024

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -118,6 +118,9 @@ struct AccountInfo: Identifiable, Codable {
     var id = UUID()
     var label: String       // e.g. "Work", "Personal"
     var credentialsPath: String
+    /// CLAUDE_CONFIG_DIR of this account; nil = the default ~/.claude login.
+    /// Optional so account lists saved by earlier versions still decode.
+    var configDir: String? = nil
 }
 
 // MARK: - Seuils de couleur partagés
@@ -946,6 +949,9 @@ class UsageManager: ObservableObject {
             self?.objectWillChange.send()
         }.store(in: &cancellables)
 
+        // The account context must be in place before the first credential load,
+        // or startup would briefly adopt the default account's token.
+        applyActiveAccountContext()
         auth.loadCredentials()
         auth.startWatchingCredentials()
 
@@ -1988,13 +1994,41 @@ class UsageManager: ObservableObject {
 
     // MARK: - Multi-account
 
-    func addAccount(label: String, path: String) {
-        accounts.append(AccountInfo(label: label, credentialsPath: path))
+    /// Point every account-scoped subsystem — credentials file, Keychain
+    /// service, session analytics, file watcher — at the selected account's
+    /// config dir. Must run before any credential load that should honor the
+    /// selection.
+    private func applyActiveAccountContext() {
+        let account = (activeAccountIndex >= 0 && activeAccountIndex < accounts.count)
+            ? accounts[activeAccountIndex] : nil
+        ActiveAccount.configDir = account?.configDir
+        auth.startWatchingCredentials()
+    }
+
+    /// Register the account living in `configDirURL` (a CLAUDE_CONFIG_DIR).
+    /// The first added account also inserts a row for the default ~/.claude
+    /// login, so there is always a way to switch back to it.
+    func addAccount(configDirURL: URL) {
+        if accounts.isEmpty {
+            let defaultCredentials = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".claude/.credentials.json")
+            accounts.append(AccountInfo(label: "Default", credentialsPath: defaultCredentials.path, configDir: nil))
+        }
+        // The Keychain service name hashes the exact directory string, so store
+        // the path in its canonical no-trailing-slash form.
+        let dir = configDirURL.standardizedFileURL.path
+        guard !accounts.contains(where: { $0.configDir == dir }) else { return }
+        accounts.append(AccountInfo(
+            label: configDirURL.lastPathComponent,
+            credentialsPath: dir + "/.credentials.json",
+            configDir: dir
+        ))
     }
 
     func switchAccount(index: Int) {
         guard index >= 0 && index < accounts.count else { return }
         activeAccountIndex = index
+        applyActiveAccountContext()
         auth.loadCredentials()
         // Don't clear quotas — keep old data until new ones arrive
         refresh()
@@ -2006,6 +2040,8 @@ class UsageManager: ObservableObject {
         if activeAccountIndex >= accounts.count {
             activeAccountIndex = max(0, accounts.count - 1)
         }
+        applyActiveAccountContext()
+        auth.loadCredentials()
     }
 
     // MARK: - Widget data sharing

--- a/Sources/UsageManager.swift
+++ b/Sources/UsageManager.swift
@@ -1016,12 +1016,28 @@ class UsageManager: ObservableObject {
         refreshStats()
     }
 
+    /// Replace the stats on screen with the active account's, pre-empting any
+    /// scan already running: `refreshStats` drops the request while one is in
+    /// flight, which on an account switch would leave the previous account's
+    /// numbers on screen until the next popover open.
+    private func forceRefreshStats() {
+        statsWorkItem?.cancel()
+        statsWorkItem = nil
+        isLoadingStats = false
+        lastStatsRefresh = nil
+        refreshStats()
+    }
+
     func refreshStats() {
         guard !isLoadingStats else { return }
         isLoadingStats = true
 
         // Cancel any previous in-flight stats work
         statsWorkItem?.cancel()
+
+        // Which account this scan reads; results from a superseded account are
+        // discarded rather than allowed to overwrite the new selection's.
+        let scannedAccount = ActiveAccount.configDir
 
         let workItem = DispatchWorkItem { [weak self] in
             let cal = Calendar.current
@@ -1037,6 +1053,7 @@ class UsageManager: ObservableObject {
             let today = month.filtered(since: todayStart)
 
             DispatchQueue.main.async {
+                guard ActiveAccount.configDir == scannedAccount else { return }
                 self?.todayStats = today
                 self?.weekStats = week
                 self?.monthStats = month
@@ -1057,9 +1074,11 @@ class UsageManager: ObservableObject {
         isLoadingTimeline = true
         timelineWorkItem?.cancel()
         let date = timelineDate
+        let scannedAccount = ActiveAccount.configDir
         let workItem = DispatchWorkItem { [weak self] in
             let sessions = SessionAnalyzer.timelineSessions(for: date)
             DispatchQueue.main.async {
+                guard ActiveAccount.configDir == scannedAccount else { return }
                 self?.timelineSessions = sessions
                 self?.isLoadingTimeline = false
             }
@@ -2005,43 +2024,91 @@ class UsageManager: ObservableObject {
         auth.startWatchingCredentials()
     }
 
+    /// `~/.claude` — where Claude Code stores the login used when
+    /// CLAUDE_CONFIG_DIR is unset.
+    private static var defaultConfigDirPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude").standardizedFileURL.path
+    }
+
+    /// The row standing for the default login, so there is always a way back.
+    private static var defaultAccount: AccountInfo {
+        AccountInfo(
+            label: "Default",
+            credentialsPath: defaultConfigDirPath + "/.credentials.json",
+            configDir: nil
+        )
+    }
+
     /// Register the account living in `configDirURL` (a CLAUDE_CONFIG_DIR).
     /// The first added account also inserts a row for the default ~/.claude
     /// login, so there is always a way to switch back to it.
     func addAccount(configDirURL: URL) {
-        if accounts.isEmpty {
-            let defaultCredentials = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude/.credentials.json")
-            accounts.append(AccountInfo(label: "Default", credentialsPath: defaultCredentials.path, configDir: nil))
-        }
         // The Keychain service name hashes the exact directory string, so store
         // the path in its canonical no-trailing-slash form.
         let dir = configDirURL.standardizedFileURL.path
-        guard !accounts.contains(where: { $0.configDir == dir }) else { return }
+        // Picking ~/.claude is the default login, not a CLAUDE_CONFIG_DIR
+        // profile: its credentials live in the un-suffixed Keychain service, so
+        // hashing that path would point the account at an item that never
+        // exists and the row could never authenticate.
+        let configDir: String? = dir == Self.defaultConfigDirPath ? nil : dir
+
+        if accounts.isEmpty {
+            accounts.append(Self.defaultAccount)
+        }
+        guard !accounts.contains(where: { $0.configDir == configDir }) else { return }
         accounts.append(AccountInfo(
             label: configDirURL.lastPathComponent,
             credentialsPath: dir + "/.credentials.json",
-            configDir: dir
+            configDir: configDir
         ))
+    }
+
+    /// Re-point every account-scoped subsystem at the current selection, then
+    /// reload everything that was derived from the account we just left: quota,
+    /// stats and timeline all outlive the switch otherwise.
+    private func reloadForActiveAccount() {
+        applyActiveAccountContext()
+        auth.resetForAccountSwitch()
+        // The quota fetch needs a token, and resolving one may go to the
+        // Keychain off the main thread — so it waits for the resolution instead
+        // of firing against the cleared state.
+        auth.reloadCredentials { [weak self] resolved in
+            guard let self else { return }
+            if resolved {
+                // Don't clear quotas — keep old data until new ones arrive
+                self.refresh()
+            } else {
+                self.errorMessage = "No credentials for this account — run `claude auth login` with its CLAUDE_CONFIG_DIR"
+            }
+        }
+        // Transcripts are read straight off disk, so these need no credentials.
+        forceRefreshStats()
+        refreshTimeline()
     }
 
     func switchAccount(index: Int) {
         guard index >= 0 && index < accounts.count else { return }
         activeAccountIndex = index
-        applyActiveAccountContext()
-        auth.loadCredentials()
-        // Don't clear quotas — keep old data until new ones arrive
-        refresh()
+        reloadForActiveAccount()
     }
 
     func removeAccount(at index: Int) {
         guard index >= 0 && index < accounts.count else { return }
+        let previousConfigDir = ActiveAccount.configDir
         accounts.remove(at: index)
+        // Removing a row above the active one shifts the selection down with it;
+        // without this, deleting an account silently switches to its neighbour.
+        if index < activeAccountIndex { activeAccountIndex -= 1 }
         if activeAccountIndex >= accounts.count {
             activeAccountIndex = max(0, accounts.count - 1)
         }
         applyActiveAccountContext()
-        auth.loadCredentials()
+        // Only pay for a full reload when the removal actually changed which
+        // account is active.
+        if ActiveAccount.configDir != previousConfigDir {
+            reloadForActiveAccount()
+        }
     }
 
     // MARK: - Widget data sharing


### PR DESCRIPTION
## Problem

The Accounts section (added in v2.8.0) stores a `credentialsPath` per account, but no code path ever reads it:

- `switchAccount()` sets the index and calls `auth.loadCredentials()`, which resolves the same default sources every time — the un-suffixed Keychain entry first, else a prefix scan that adopts whichever `Claude Code-credentials*` entry has the freshest token.
- The "Add" button always registers the same hardcoded default path, so every row is identical.
- The session timeline/cost analytics are pinned to `~/.claude/projects`.

With two logins on one machine (`CLAUDE_CONFIG_DIR` profiles), switching rows toggles the green dot but all rows show the same account's quota and sessions.

## Fix

Claude Code namespaces per config directory: `CLAUDE_CONFIG_DIR` unset → `~/.claude` + Keychain service `Claude Code-credentials`; `CLAUDE_CONFIG_DIR=D` → `D` + `Claude Code-credentials-<sha256(D)[0:8]>`. A new `ActiveAccount` context resolves the active account's credentials file, Keychain service, and `projects/` dir from its config dir, and `AuthManager` / `SessionAnalyzer` / `UsageManager` route through it. A pinned account matches its exact Keychain service — no more freshest-token bleed between accounts. "Add" now opens a directory picker for the account's config dir (hidden files visible, since these dirs are dotfolders), and adding the first account inserts a "Default" row for the `~/.claude` login.

Backward compatible: `configDir` is optional on `AccountInfo`, so account lists saved by earlier versions still decode (they behave as the default login until re-added). With no accounts configured, behavior is unchanged, including the prefix-scan fallback.

## Notes

- The `-<sha256(dir)[0:8]>` suffix scheme is observed from Claude Code ≥ 2.x behavior (verified against a real profile's Keychain entry); it hashes the exact directory string, which is why the picker stores the canonical no-trailing-slash path.
- Tested on macOS with two accounts: one default `~/.claude` login and one `CLAUDE_CONFIG_DIR` profile — quota rings, session timeline, and costs all follow the selected row; token refresh writes back to the correct per-account Keychain item.